### PR TITLE
Create skeleton for FRED data ingestion platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,19 @@ This is an internal repository. Follow the established coding standards and ensu
 
 ## License
 Internal use only. All rights reserved.
+
+## FRED Data Platform Skeleton
+
+The repository now includes an initial scaffolding for the planned FRED
+indicator ingestion system. Relevant entry points:
+
+- `configs/fred_series_catalog.template.yaml` – template for mapping
+  stakeholder categories to FRED series identifiers.
+- `src/lhm/config/series_catalog.py` – loader utilities for the catalog.
+- `src/lhm/clients/fred_client.py` – stubbed API client to be expanded in
+  the next phase.
+- `src/lhm/pipelines/daily_refresh.py` – shell for the daily refresh
+  pipeline coordinating ingestion and persistence.
+
+Refer to `docs/fred_data_platform.md` for additional context and the
+roadmap for completing the ingestion workflow.

--- a/configs/fred_series_catalog.template.yaml
+++ b/configs/fred_series_catalog.template.yaml
@@ -1,0 +1,24 @@
+# Catalog of FRED series grouped by stakeholder-defined categories.
+#
+# This skeleton document is intentionally light on content. The follow-up
+# task will populate each category with 50-100 vetted time series once the
+# stakeholder confirms the proposed structure. Each entry should provide
+# at minimum the ``series_id`` and a human-readable ``title``.
+categories:
+  gdp:
+    - series_id: GDP
+      title: Gross Domestic Product, Billions of Dollars, Quarterly, SAAR
+      frequency: Quarterly
+      units: Billions of Dollars
+      seasonal_adjustment: Seasonally Adjusted Annual Rate
+      notes: Placeholder entry demonstrating the schema; the full catalog will be curated next.
+  labor: []
+  prices: []
+  health: []
+  money: []
+  trade: []
+  government: []
+  business: []
+  consumer: []
+  housing: []
+  taxes: []

--- a/docs/fred_data_platform.md
+++ b/docs/fred_data_platform.md
@@ -1,0 +1,44 @@
+# FRED Data Platform Skeleton
+
+This document summarises the scaffolding that will power the automated
+retrieval of FRED indicators once the catalog of series has been
+approved.
+
+## Objectives
+
+1. Provide a clearly structured configuration layer where each category
+   maps to a curated list of FRED series (50-100 per category).
+2. Separate the concerns of configuration, data acquisition, storage,
+   and orchestration so that each layer can evolve independently.
+3. Prepare for a daily refresh cadence that rehydrates recent
+   observations while respecting FRED's rate limits and terms of use.
+
+## High-Level Architecture
+
+| Layer        | Responsibility                                                      |
+| ------------ | ------------------------------------------------------------------- |
+| Config       | Defines series metadata, API credentials, and storage preferences. |
+| Client       | Handles authenticated calls to FRED and response validation.        |
+| Pipelines    | Orchestrates recurring refresh jobs and error handling.             |
+| Storage      | Persists data in the agreed upon analytics format.                  |
+
+## Key Modules
+
+- `lhm.config.series_catalog.SeriesCatalog`: Loads and validates the
+  category -> series mapping from YAML.
+- `lhm.clients.fred_client.FREDClient`: Placeholder interface for the
+  HTTP client that will communicate with FRED.
+- `lhm.pipelines.daily_refresh.DailyRefreshPipeline`: Coordinates the
+  daily ingestion cycle.
+- `lhm.storage.registry.StorageRegistry`: Future entry point for
+  storage backends (e.g., local parquet, cloud data warehouse).
+
+## Next Steps
+
+- Finalise the list of 50-100 FRED series per category.
+- Implement the concrete FRED client, including authentication and
+  throttling.
+- Introduce persistence utilities aligned with the stakeholder's data
+  lake/warehouse standards.
+- Add CI workflows and automated tests once the functional components
+  are in place.

--- a/docs/fred_series_catalog_outline.md
+++ b/docs/fred_series_catalog_outline.md
@@ -1,0 +1,25 @@
+# FRED Series Catalog Outline
+
+The following table captures the ten macroeconomic categories requested
+by the stakeholder. Each category will eventually contain 50-100 vetted
+FRED series. The present outline documents the curation status and notes
+open questions that will be resolved prior to implementation of the
+fetching logic.
+
+| Category  | Description | Current Status | Next Actions |
+| --------- | ----------- | -------------- | ------------ |
+| GDP       | Aggregate output measures such as GDP, GDI, and potential GDP. | Placeholder entry created in `configs/fred_series_catalog.template.yaml`. | Compile full list of national accounts series and confirm seasonal adjustment preferences. |
+| Labor     | Employment, unemployment, hours worked, participation rates. | Pending. | Identify BLS-based series (e.g., payrolls, unemployment rate) and ensure availability in FRED. |
+| Prices    | Inflation, price indices, producer prices, deflators. | Pending. | Gather CPI, PCE, PPI, GDP deflators, and survey-based inflation expectations. |
+| Health    | Healthcare expenditure, insurance coverage, health outcomes. | Pending. | Source data from CMS, BEA health satellite accounts, CDC series present in FRED. |
+| Money     | Monetary aggregates, interest rates, credit measures. | Pending. | Confirm coverage of M1/M2, monetary base, bank credit, interest rates. |
+| Trade     | Exports, imports, balance of trade, exchange rates. | Pending. | Assemble goods/services trade series and trade-weighted exchange rates. |
+| Government| Fiscal revenue/expenditure, debt, budget balances. | Pending. | Collect Treasury statement series and NIPA government spending metrics. |
+| Business  | Business sentiment, production, investment, inventories. | Pending. | Include ISM indices, industrial production components, capital goods orders. |
+| Consumer  | Spending, confidence, credit, income distribution metrics. | Pending. | Combine retail sales, personal income/outlays, consumer credit series. |
+| Housing   | Construction, sales, prices, mortgage data. | Pending. | Combine housing starts, permits, sales, price indices, mortgage rates. |
+| Taxes     | Federal, state, and local tax receipts and rates. | Pending. | Identify FRED series sourced from BEA, Treasury, and IRS. |
+
+The next iteration will expand this outline with the concrete list of
+series identifiers, including validation that each FRED series is active
+and up to date.

--- a/src/lhm/__init__.py
+++ b/src/lhm/__init__.py
@@ -1,0 +1,20 @@
+"""Core package for the LHM data platform."""
+
+from importlib import resources
+
+
+def get_version() -> str:
+    """Return the package version if metadata is available.
+
+    The skeleton package does not yet ship with a build system that
+    automatically injects version metadata. The helper gracefully
+    falls back to ``"0.0.0"`` so that downstream modules have a
+    reliable semantic version string to reference during early
+    development.
+    """
+
+    try:
+        with resources.files(__package__).joinpath("VERSION").open("r", encoding="utf-8") as handle:
+            return handle.read().strip()
+    except FileNotFoundError:
+        return "0.0.0"

--- a/src/lhm/clients/__init__.py
+++ b/src/lhm/clients/__init__.py
@@ -1,0 +1,5 @@
+"""External service clients used by the ingestion pipelines."""
+
+from .fred_client import FREDClient, FREDSeries
+
+__all__ = ["FREDClient", "FREDSeries"]

--- a/src/lhm/clients/fred_client.py
+++ b/src/lhm/clients/fred_client.py
@@ -1,0 +1,63 @@
+"""Minimal FRED client stub for future implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Iterable, Protocol
+
+
+@dataclass(frozen=True)
+class FREDSeries:
+    """Series metadata returned by FRED."""
+
+    series_id: str
+    title: str
+    frequency: str | None = None
+    observation_start: date | None = None
+    observation_end: date | None = None
+
+
+class HTTPBackend(Protocol):
+    """Protocol for HTTP clients used by :class:`FREDClient`."""
+
+    def get(self, url: str, params: dict[str, str]) -> dict:  # pragma: no cover - skeleton placeholder
+        ...
+
+
+class FREDClient:
+    """Lightweight wrapper around the FRED API.
+
+    The skeleton client exposes the interface that downstream pipeline
+    code will rely on. The actual HTTP implementation will be added in a
+    follow-up once the data catalog has been validated.
+    """
+
+    def __init__(self, api_key: str | None, base_url: str, http_backend: HTTPBackend | None = None) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self._http = http_backend
+
+    def list_series(self, series_ids: Iterable[str]) -> list[FREDSeries]:  # pragma: no cover - skeleton placeholder
+        """Return metadata for the requested series.
+
+        Implementation to be provided in the next iteration. The method is
+        included so that pipeline code can be prototyped against a stable
+        contract.
+        """
+
+        raise NotImplementedError("FREDClient.list_series is pending implementation")
+
+    def fetch_observations(
+        self,
+        series_id: str,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> None:  # pragma: no cover - skeleton placeholder
+        """Download observations for a given series.
+
+        The data retrieval strategy will be implemented after the
+        stakeholder confirms the catalog of series.
+        """
+
+        raise NotImplementedError("FREDClient.fetch_observations is pending implementation")

--- a/src/lhm/config/__init__.py
+++ b/src/lhm/config/__init__.py
@@ -1,0 +1,13 @@
+"""Configuration helpers for the LHM data acquisition system."""
+
+from .series_catalog import Category, SeriesDefinition, SeriesCatalog
+from .settings import FREDConfig, StorageConfig, PipelineConfig
+
+__all__ = [
+    "Category",
+    "SeriesCatalog",
+    "SeriesDefinition",
+    "FREDConfig",
+    "StorageConfig",
+    "PipelineConfig",
+]

--- a/src/lhm/config/series_catalog.py
+++ b/src/lhm/config/series_catalog.py
@@ -1,0 +1,97 @@
+"""Series catalog definitions for structured FRED ingestion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Iterable, List, Mapping
+
+import yaml
+
+
+class Category(str, Enum):
+    """High-level macroeconomic groupings requested by the stakeholder."""
+
+    GDP = "gdp"
+    LABOR = "labor"
+    PRICES = "prices"
+    HEALTH = "health"
+    MONEY = "money"
+    TRADE = "trade"
+    GOVERNMENT = "government"
+    BUSINESS = "business"
+    CONSUMER = "consumer"
+    HOUSING = "housing"
+    TAXES = "taxes"
+
+
+@dataclass(frozen=True)
+class SeriesDefinition:
+    """Describe a single FRED series and its metadata."""
+
+    series_id: str
+    title: str
+    frequency: str | None = None
+    units: str | None = None
+    seasonal_adjustment: str | None = None
+    notes: str | None = None
+
+
+@dataclass
+class SeriesCatalog:
+    """Container grouping the series definitions by category."""
+
+    categories: Mapping[Category, List[SeriesDefinition]] = field(default_factory=dict)
+
+    @classmethod
+    def from_yaml(cls, handle: Iterable[str]) -> "SeriesCatalog":
+        """Create a catalog from a YAML document."""
+
+        payload = yaml.safe_load(handle)
+        categories: dict[Category, List[SeriesDefinition]] = {}
+        for raw_category, raw_series in payload.get("categories", {}).items():
+            category = Category(raw_category)
+            definitions = [SeriesDefinition(**entry) for entry in raw_series or []]
+            categories[category] = definitions
+        return cls(categories=categories)
+
+    @classmethod
+    def load(cls, path: str | Path) -> "SeriesCatalog":
+        """Load a YAML catalog from disk."""
+
+        with Path(path).expanduser().open("r", encoding="utf-8") as handle:
+            return cls.from_yaml(handle)
+
+    def to_yaml_dict(self) -> dict:
+        """Represent the catalog as a serialisable dictionary."""
+
+        return {
+            "categories": {
+                category.value: [
+                    {
+                        "series_id": definition.series_id,
+                        "title": definition.title,
+                        "frequency": definition.frequency,
+                        "units": definition.units,
+                        "seasonal_adjustment": definition.seasonal_adjustment,
+                        "notes": definition.notes,
+                    }
+                    for definition in definitions
+                ]
+                for category, definitions in sorted(self.categories.items(), key=lambda item: item[0].value)
+            }
+        }
+
+    def dump(self, path: str | Path) -> None:
+        """Persist the catalog to disk."""
+
+        with Path(path).expanduser().open("w", encoding="utf-8") as handle:
+            yaml.safe_dump(self.to_yaml_dict(), handle, sort_keys=False, allow_unicode=True)
+
+    def iter_series(self) -> Iterable[tuple[Category, SeriesDefinition]]:
+        """Iterate over ``(category, series_definition)`` tuples."""
+
+        for category, definitions in self.categories.items():
+            for definition in definitions:
+                yield category, definition

--- a/src/lhm/config/settings.py
+++ b/src/lhm/config/settings.py
@@ -1,0 +1,33 @@
+"""Settings dataclasses used to configure the data platform."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class FREDConfig:
+    """Connection parameters for the FRED API."""
+
+    api_key: str | None = None
+    base_url: str = "https://api.stlouisfed.org"
+    rate_limit_per_minute: int = 60
+
+
+@dataclass(slots=True)
+class StorageConfig:
+    """Describe how fetched series should be stored locally."""
+
+    root_path: Path = Path("data/raw/fred")
+    format: str = "parquet"
+
+
+@dataclass(slots=True)
+class PipelineConfig:
+    """Top-level configuration for the recurring ingestion pipeline."""
+
+    fred: FREDConfig = FREDConfig()
+    storage: StorageConfig = StorageConfig()
+    catalog_path: Path = Path("configs/fred_series_catalog.yaml")
+    refresh_window_days: int = 7

--- a/src/lhm/pipelines/__init__.py
+++ b/src/lhm/pipelines/__init__.py
@@ -1,0 +1,5 @@
+"""Pipeline orchestrators for recurring data pulls."""
+
+from .daily_refresh import DailyRefreshPipeline
+
+__all__ = ["DailyRefreshPipeline"]

--- a/src/lhm/pipelines/daily_refresh.py
+++ b/src/lhm/pipelines/daily_refresh.py
@@ -1,0 +1,59 @@
+"""Skeleton implementation of the daily refresh pipeline."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable
+
+from ..clients import FREDClient
+from ..config import Category, PipelineConfig, SeriesDefinition, SeriesCatalog
+
+
+class DailyRefreshPipeline:
+    """Coordinate the ingestion of FRED series on a rolling basis."""
+
+    def __init__(self, config: PipelineConfig, client: FREDClient, catalog: SeriesCatalog) -> None:
+        self.config = config
+        self.client = client
+        self.catalog = catalog
+
+    def resolve_refresh_window(self) -> tuple[datetime | None, datetime | None]:
+        """Return the date window that should be refreshed.
+
+        The skeleton implementation assumes that the caller will
+        re-download the last ``refresh_window_days`` worth of data to
+        capture any historical revisions. The concrete implementation will
+        be expanded once the stakeholder signs off on the series catalog
+        and storage approach.
+        """
+
+        end = datetime.utcnow()
+        start = end - timedelta(days=self.config.refresh_window_days)
+        return start, end
+
+    def iter_catalog(self) -> Iterable[tuple[Category, SeriesDefinition]]:
+        """Helper proxy exposing the catalog entries."""
+
+        return self.catalog.iter_series()
+
+    def run(self) -> None:  # pragma: no cover - skeleton placeholder
+        """Execute a refresh cycle.
+
+        The method will be populated with the following steps once the
+        catalog is approved:
+
+        * resolve the refresh window
+        * fetch observations for each series in the catalog
+        * persist data to the configured storage backend
+        * emit operational metrics/logs
+        """
+
+        raise NotImplementedError("DailyRefreshPipeline.run is pending implementation")
+
+    @classmethod
+    def load_default_catalog(cls, path: str | Path | None = None) -> SeriesCatalog:
+        """Convenience loader for the default catalog path."""
+
+        catalog_path = path or PipelineConfig().catalog_path
+        return SeriesCatalog.load(catalog_path)

--- a/src/lhm/storage/__init__.py
+++ b/src/lhm/storage/__init__.py
@@ -1,0 +1,5 @@
+"""Storage utilities for persisting FRED datasets."""
+
+from .registry import StorageRegistry
+
+__all__ = ["StorageRegistry"]

--- a/src/lhm/storage/registry.py
+++ b/src/lhm/storage/registry.py
@@ -1,0 +1,32 @@
+"""Placeholder registry for storage backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from ..config import StorageConfig
+
+
+class StorageBackend(Protocol):
+    """Interface for storage backends used by the pipelines."""
+
+    def save(self, series_id: str, path: Path, payload: object) -> None:  # pragma: no cover - skeleton placeholder
+        ...
+
+
+@dataclass
+class StorageRegistry:
+    """Registry mapping storage identifiers to backend implementations."""
+
+    config: StorageConfig
+
+    def resolve(self, backend_name: str) -> StorageBackend:  # pragma: no cover - skeleton placeholder
+        """Return the backend implementation for ``backend_name``.
+
+        The implementation is intentionally deferred until we decide on the
+        canonical storage layout (e.g., Parquet files, DuckDB, Postgres).
+        """
+
+        raise NotImplementedError("StorageRegistry.resolve is pending implementation")


### PR DESCRIPTION
## Summary
- add a Python package skeleton under `src/lhm` to host configuration, client, pipeline, and storage modules for FRED ingestion
- draft documentation outlining the planned architecture and series curation workflow
- introduce a YAML catalog template that will store the 50-100 indicators per stakeholder category once curated

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_68e7b4c4f248832bb6acf9e01f230a8f)

## Summary by Sourcery

Provide a scaffold for the FRED data ingestion platform by adding a Python package structure with configuration, client, pipeline, and storage modules, a series catalog template, and accompanying documentation outlining the planned architecture and workflows.

New Features:
- Add Python package skeleton with config, clients, pipelines, and storage modules
- Introduce YAML template for the FRED series catalog

Enhancements:
- Implement dataclass-based settings and series catalog loader and dumper
- Define stub FREDClient interface and DailyRefreshPipeline with refresh window resolution
- Provide StorageRegistry protocol and get_version helper in package init

Documentation:
- Add documentation covering architecture, workflow roadmap, and series catalog outline
- Update README to reference new scaffold components

Chores:
- Initial project scaffolding under src/lhm