### PR TITLE
charts: universal annotation placement (top-center, wrap at 20 chars)

### DIFF
--- a/Brand/chart-styling-for-gemini.md
+++ b/Brand/chart-styling-for-gemini.md
@@ -259,11 +259,37 @@ Use on expectations charts where 3% is the de-anchoring threshold.
 
 ## Annotation Box (Takeaway)
 
-Every chart should have an annotation box with 1-2 line commentary summarizing the takeaway. Positioned in dead space where there is no data.
+**Use sparingly.** A strong chart with a tight caption almost always beats an in-chart annotation. Only add an annotation when it carries information the chart itself cannot show (regime call, multi-series takeaway, non-obvious causal note). If the visual already tells the story, skip the box.
+
+### Universal Placement Rule (v4.1, May 2026)
+
+Every annotation box uses the same anchor — no per-chart overrides:
+
+- **Position:** `x=0.5, y=0.98` in axes coordinates
+- **Alignment:** `ha='center'`, `va='top'`
+- **Wrapping:** Wrap to a new line when a line would exceed **20 characters** left-to-right. Use `textwrap.fill(..., width=20, break_long_words=False, break_on_hyphens=False)`. Preserve explicit `\n`; wrap each segment independently.
 
 ```python
-def add_annotation_box(ax, text, x=0.52, y=0.92):
-    ax.text(x, y, text, transform=ax.transAxes,
+import textwrap
+
+def _wrap_annotation_text(text, width=20):
+    if not text:
+        return text
+    out = []
+    for line in text.split('\n'):
+        if line.strip() == '':
+            out.append(line)
+        else:
+            out.append(textwrap.fill(line, width=width,
+                                     break_long_words=False,
+                                     break_on_hyphens=False))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=0.5, y=0.98, wrap_width=20):
+    """Top-center, auto-wrapped at 20 chars. Do NOT override x/y."""
+    ax.text(x, y, _wrap_annotation_text(text, wrap_width),
+            transform=ax.transAxes,
             fontsize=10, color=THEME['fg'], ha='center', va='top',
             style='italic',
             bbox=dict(boxstyle='round,pad=0.5',
@@ -271,21 +297,21 @@ def add_annotation_box(ax, text, x=0.52, y=0.92):
                       alpha=0.9))
 ```
 
-- **Border color**: Always Ocean `#2389BB` (hardcoded, not theme-driven)
-- **Background**: Theme background color (opaque)
+- **Border color**: Always Ocean `#2389BB`
+- **Background**: Theme background, `alpha=0.9`
 - **Text**: Theme foreground, italic, fontsize 10
-- **Default position**: `x=0.52, y=0.92` (slightly right of center, near top)
-- **CRITICAL: All annotation text must be dynamic** — use f-strings with live data values. Never hardcode numbers.
+- **Position**: `x=0.5, y=0.98`. **Do not override.** If the box overlaps data, delete the annotation; don't move it.
+- **CRITICAL**: All annotation text must be dynamic — f-strings with live data values. Never hardcode numbers.
 
-### Position Guidelines
-Override `x` and `y` to place the box in the largest empty area:
+### When to Annotate vs. Caption
 
-| Scenario | Suggested Position |
+| Situation | Use annotation box? |
 |---|---|
-| Data heavy on left, empty right-top | `x=0.52, y=0.92` (default) |
-| Data heavy on top, empty bottom | `x=0.52, y=0.12` |
-| Data heavy on right, empty left-top | `x=0.35, y=0.92` |
-| Centered data, empty corners | `x=0.45, y=0.92` |
+| The chart already makes the point visually | No — write a caption |
+| Single takeaway computed from 2+ series | Yes |
+| Naming the current regime | Yes |
+| Long-form context, history, mechanism | No — body text |
+| Multiple competing takeaways | No — pick one |
 
 Always verify visually that the box does not overlap data, legend, recession shading, or pills.
 

--- a/Brand/chart-styling.md
+++ b/Brand/chart-styling.md
@@ -280,11 +280,48 @@ Use on expectations charts where 3% is the de-anchoring threshold.
 
 ## Annotation Box (Takeaway)
 
-Every chart should have an annotation box with 1-2 line commentary summarizing the takeaway. Positioned in dead space where there is no data.
+**Use sparingly.** A strong chart with a tight caption is almost always better than an in-chart annotation box. Only add an annotation when it carries information the chart itself cannot show (e.g., a regime call, a non-obvious causal note, a numerical takeaway that requires multiple series to compute). If the visual already tells the story, skip the box.
+
+### Universal Placement Rule (v4.1, May 2026)
+
+Every annotation box uses the same anchor, with no per-chart overrides:
+
+- **Position:** `x=0.5, y=0.98` in axes coordinates
+- **Alignment:** `ha='center'`, `va='top'`
+- **Wrapping:** Text wraps to a new line whenever a line would exceed **20 characters** left-to-right. Wrapping uses `textwrap.fill(..., width=20, break_long_words=False, break_on_hyphens=False)` so words are not split mid-token. Existing explicit `\n` in the source text is preserved; each segment is wrapped independently.
+
+Why: Bob's rule, codified after repeated cases of annotations sitting on top of data. A fixed top-center anchor with narrow wrapping keeps the box predictable, leaves the rest of the plot for data, and forces authors to keep takeaway text short. If top-center genuinely overlaps a critical series (rare — series usually peak in the middle, not the top-left/top-right where wrapping puts text), **remove the annotation** rather than reposition it. The chart-and-caption combo is the canonical alternative.
+
+### Canonical Implementation
 
 ```python
-def add_annotation_box(ax, text, x=0.52, y=0.92):
-    ax.text(x, y, text, transform=ax.transAxes,
+import textwrap
+
+def _wrap_annotation_text(text, width=20):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words."""
+    if not text:
+        return text
+    lines = text.split('\n')
+    wrapped = []
+    for line in lines:
+        if line.strip() == '':
+            wrapped.append(line)
+            continue
+        wrapped.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(wrapped)
+
+
+def add_annotation_box(ax, text, x=0.5, y=0.98, wrap_width=20):
+    """Takeaway box, top-center, auto-wrapped at 20 chars.
+
+    Do NOT override x/y per chart. The placement is universal."""
+    wrapped = _wrap_annotation_text(text, width=wrap_width)
+    ax.text(x, y, wrapped, transform=ax.transAxes,
             fontsize=10, color=THEME['fg'], ha='center', va='top',
             style='italic',
             bbox=dict(boxstyle='round,pad=0.5',
@@ -293,18 +330,20 @@ def add_annotation_box(ax, text, x=0.52, y=0.92):
 ```
 
 - **Border color**: Always Ocean `#2389BB` (hardcoded, not theme-driven)
-- **Background**: Theme background color (opaque)
+- **Background**: Theme background color (opaque, `alpha=0.9` on white theme so any underlying line is muted, not erased)
 - **Text**: Theme foreground, italic, fontsize 10
-- **Default position**: `x=0.52, y=0.92` (slightly right of center, near top)
+- **Position**: `x=0.5, y=0.98`. **Do not override.** If the box overlaps data, delete the annotation; don't move it.
 - **CRITICAL: All annotation text must be dynamic** — use f-strings with live data values. Never hardcode numbers.
 
-### Position Guidelines
+### When to Annotate vs. Caption
 
-Override `x` and `y` to place the box in the largest empty area:
-
-ScenarioSuggested PositionData heavy on left, empty right-top`x=0.52, y=0.92` (default)Data heavy on top, empty bottom`x=0.52, y=0.12`Data heavy on right, empty left-top`x=0.35, y=0.92`Centered data, empty corners`x=0.45, y=0.92`
-
-Always verify visually that the box does not overlap data, legend, recession shading, or pills.
+| Situation | Use annotation box? |
+|-----------|---------------------|
+| The chart already makes the point visually | No — write a caption instead |
+| Single takeaway number requiring 2+ series to compute (e.g. "spread is at 87th pctile") | Yes |
+| Naming the current regime ("Crisis", "On target") | Yes — keep it short, wrap will trim it |
+| Long-form context, history, mechanism | No — use the surrounding article body |
+| Multiple competing takeaways | No — pick one for the chart, defer the rest |
 
 ---
 

--- a/Scripts/build_validation_report.py
+++ b/Scripts/build_validation_report.py
@@ -78,8 +78,7 @@ def fig_summary_bar(summary):
     ax.set_ylim(min(ics) - 0.10, max(ics) + 0.15)
 
     add_annotation_box(ax,
-        '|t| ≥ 2.0 = statistically significant. Three pillars (Prices, Housing, Government) clear that bar.',
-        x=0.50, y=0.96)
+        '|t| ≥ 2.0 = statistically significant. Three pillars (Prices, Housing, Government) clear that bar.')
 
     brand_fig(fig,
         title='Pillar Validation: walk-forward 63d-forward IC vs benchmark',

--- a/Scripts/chart_generation/btc_etf_charts.py
+++ b/Scripts/chart_generation/btc_etf_charts.py
@@ -5,6 +5,7 @@ Uses REAL data from Farside Investors + yfinance + DefiLlama
 """
 
 import os
+import textwrap
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import matplotlib.image as mpimg
@@ -267,8 +268,45 @@ def add_outer_border(fig):
     ))
 
 
-def add_annotation_box(ax, text, x=0.52, y=0.08):
-    """Add takeaway box - default to bottom of chart area."""
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     ax.text(x, y, text, transform=ax.transAxes,
             fontsize=10, color=THEME['fg'], ha='center', va='bottom', style='italic',
             bbox=dict(boxstyle='round,pad=0.5', facecolor=THEME['bg'],
@@ -343,7 +381,7 @@ def chart_01_etf_flows():
 
     # Branding
     brand_fig(fig, 'THE SPOT CAPITULATION', 'Cumulative ETF Flows vs. BTC Price', source='Farside Investors, Yahoo Finance')
-    add_annotation_box(ax1, f"Outflows since peak: ${outflows_since_peak:,.0f}M  |  Price vs. peak: {price_drawdown:+.1f}%", x=0.5, y=0.03)
+    add_annotation_box(ax1, f"Outflows since peak: ${outflows_since_peak:,.0f}M  |  Price vs. peak: {price_drawdown:+.1f}%")
 
     # Legend
     lines = [l1, l2]
@@ -408,7 +446,7 @@ def chart_02_flow_momentum():
 
     # Count days of negative momentum
     recent_neg = (df['Flow_30d'].iloc[-30:] < 0).sum()
-    add_annotation_box(ax1, f"Negative momentum: {recent_neg}/30 recent days", x=0.5, y=0.03)
+    add_annotation_box(ax1, f"Negative momentum: {recent_neg}/30 recent days")
 
     # Legend
     lines = [l1, l2]
@@ -465,7 +503,7 @@ def chart_03_onchain():
 
     # Branding
     brand_fig(fig, 'THE ON-CHAIN REALITY', 'Base Chain Total Value Locked', source='DefiLlama')
-    add_annotation_box(ax, f"12-month TVL growth: +{growth_pct:.0f}%  |  Price falls, infrastructure grows.", x=0.5, y=0.03)
+    add_annotation_box(ax, f"12-month TVL growth: +{growth_pct:.0f}%  |  Price falls, infrastructure grows.")
 
     # Legend
     ax.legend(loc='upper left', **legend_style())
@@ -526,7 +564,7 @@ def chart_04_gbtc_vs_rest():
 
     # Branding
     brand_fig(fig, 'THE GBTC EXODUS', 'Grayscale Outflows vs. New ETF Inflows', source='Farside Investors')
-    add_annotation_box(ax1, f"GBTC: ${gbtc_cum.iloc[-1]/1000:.1f}B out  |  Others: +${rest_cum.iloc[-1]/1000:.1f}B in", x=0.5, y=0.03)
+    add_annotation_box(ax1, f"GBTC: ${gbtc_cum.iloc[-1]/1000:.1f}B out  |  Others: +${rest_cum.iloc[-1]/1000:.1f}B in")
 
     # Legend
     lines = [l1, l2]
@@ -595,7 +633,7 @@ def chart_05_largest_flows():
     # Find the biggest outflow
     worst_day = flows_raw['Total'].idxmin()
     worst_val = flows_raw['Total'].min()
-    add_annotation_box(ax, f"Largest outflow: ${worst_val:,.0f}M on {worst_day.strftime('%b %d, %Y')}", x=0.25, y=0.03)
+    add_annotation_box(ax, f"Largest outflow: ${worst_val:,.0f}M on {worst_day.strftime('%b %d, %Y')}")
 
     # Margins and border
     fig.subplots_adjust(top=0.86, bottom=0.10, left=0.15, right=0.94)
@@ -670,7 +708,7 @@ def chart_06_flow_zscore_30d():
 
     # Branding
     brand_fig(fig, 'FLOW MOMENTUM Z-SCORE (30D)', '30-Day Rolling Flow Sum (Standardized)', source='Farside Investors')
-    add_annotation_box(ax, f"{regime}  |  {outliers_down} periods below -1σ historically", x=0.5, y=0.03)
+    add_annotation_box(ax, f"{regime}  |  {outliers_down} periods below -1σ historically")
 
     # Add +1/-1 labels
     ax.text(0.02, 1.1, '+1σ', fontsize=9, color=c_primary, alpha=0.7,
@@ -757,7 +795,7 @@ def chart_07_flow_zscore_90d():
 
     # Branding
     brand_fig(fig, 'THE SILENT CAPITULATION', '90-Day Flow Momentum (Standardized)', source='Farside Investors')
-    add_annotation_box(ax, f"{regime}  |  {note}", x=0.5, y=0.03)
+    add_annotation_box(ax, f"{regime}  |  {note}")
 
     # Add +1/-1 labels
     ax.text(0.02, 1.1, '+1σ', fontsize=9, color=c_primary, alpha=0.7,
@@ -860,7 +898,7 @@ def chart_08_base_cbbtc():
 
     # Branding
     brand_fig(fig, 'THE CAPITAL ROTATION', 'Base Chain TVL & cbBTC Market Cap Growth', source='DefiLlama, User Research')
-    add_annotation_box(ax1, f"Base TVL: 9x since Jan 2024  |  cbBTC: 0 → $6B since Sep 2024  |  Capital is moving, not leaving.", x=0.5, y=0.03)
+    add_annotation_box(ax1, f"Base TVL: 9x since Jan 2024  |  cbBTC: 0 → $6B since Sep 2024  |  Capital is moving, not leaving.")
 
     # Legend
     lines = [l1, l2]
@@ -913,7 +951,7 @@ def chart_09_onchain_metrics():
 
     # Branding
     brand_fig(fig, 'ON-CHAIN ACCUMULATION SIGNALS', 'MVRV, NUPL, SOPR (CryptoQuant, Feb 4, 2026)', source='CryptoQuant')
-    add_annotation_box(ax, "All three metrics signal accumulation zone. SOPR <1.0 = sellers realizing losses.", x=0.5, y=0.03)
+    add_annotation_box(ax, "All three metrics signal accumulation zone. SOPR <1.0 = sellers realizing losses.")
 
     # Margins and border
     fig.subplots_adjust(top=0.86, bottom=0.10, left=0.12, right=0.94)
@@ -966,7 +1004,7 @@ def chart_10_exchange_flows():
 
     # Branding
     brand_fig(fig, 'EXCHANGE EXODUS', 'Net BTC Flows to/from Exchanges', source='CryptoQuant (Illustrative)')
-    add_annotation_box(ax, "Coins leaving exchanges → Cold storage. Bullish supply dynamics.", x=0.5, y=0.03)
+    add_annotation_box(ax, "Coins leaving exchanges → Cold storage. Bullish supply dynamics.")
 
     # Margins and border
     fig.subplots_adjust(top=0.86, bottom=0.10, left=0.08, right=0.94)
@@ -1012,7 +1050,7 @@ def chart_11_sovereign_holdings():
 
     # Branding
     brand_fig(fig, 'SOVEREIGN HANDS', 'Known Government Bitcoin Holdings', source='Public Blockchain Data, BitcoinTreasuries')
-    add_annotation_box(ax, "Smart money accumulates during stress. Bhutan: $765M profit on $120M cost basis.", x=0.5, y=0.03)
+    add_annotation_box(ax, "Smart money accumulates during stress. Bhutan: $765M profit on $120M cost basis.")
 
     # Margins and border
     fig.subplots_adjust(top=0.86, bottom=0.10, left=0.15, right=0.94)

--- a/Scripts/chart_generation/btc_etf_interactive_charts.py
+++ b/Scripts/chart_generation/btc_etf_interactive_charts.py
@@ -4,6 +4,7 @@ Extracted from HTML interactive report and rendered in Lighthouse Macro style
 """
 
 import os
+import textwrap
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import matplotlib.image as mpimg
@@ -119,8 +120,45 @@ def add_outer_border(fig):
     ))
 
 
-def add_annotation_box(ax, text, x=0.52, y=0.08):
-    """Add takeaway box - default to bottom of chart area."""
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     ax.text(x, y, text, transform=ax.transAxes,
             fontsize=10, color=THEME['fg'], ha='center', va='bottom', style='italic',
             bbox=dict(boxstyle='round,pad=0.5', facecolor=THEME['bg'],
@@ -209,7 +247,7 @@ def chart_zscore_interactive():
 
     # Branding
     brand_fig(fig, 'THE SILENT CAPITULATION', '90-Day Flow Momentum Z-Score', source='Farside Investors')
-    add_annotation_box(ax, "Outflow regime  |  NEAR ALL-TIME LOWS (-1.93σ)", x=0.5, y=0.03)
+    add_annotation_box(ax, "Outflow regime  |  NEAR ALL-TIME LOWS (-1.93σ)")
 
     # Margins and border
     fig.subplots_adjust(top=0.86, bottom=0.10, left=0.08, right=0.94)
@@ -267,7 +305,7 @@ def chart_cumulative_interactive():
     brand_fig(fig, 'CUMULATIVE ETF FLOWS', 'Net Inflows Since Launch ($ Billions)', source='Farside Investors')
 
     drawdown = cum_flows[-1] - cum_flows[peak_idx]
-    add_annotation_box(ax, f"${cum_flows[-1]:.1f}B total  |  ${drawdown:.1f}B bleed since peak", x=0.5, y=0.03)
+    add_annotation_box(ax, f"${cum_flows[-1]:.1f}B total  |  ${drawdown:.1f}B bleed since peak")
 
     # Margins and border
     fig.subplots_adjust(top=0.86, bottom=0.10, left=0.08, right=0.94)
@@ -312,7 +350,7 @@ def chart_base_tvl_interactive():
 
     # Branding
     brand_fig(fig, 'BASE CHAIN TVL GROWTH', 'Total Value Locked (DeFi)', source='DefiLlama')
-    add_annotation_box(ax, f"+{growth:.0f}% growth  |  Aerodrome commands >40% of liquidity", x=0.5, y=0.88)
+    add_annotation_box(ax, f"+{growth:.0f}% growth  |  Aerodrome commands >40% of liquidity")
 
     # Margins and border
     fig.subplots_adjust(top=0.86, bottom=0.10, left=0.08, right=0.94)
@@ -362,7 +400,7 @@ def chart_cbbtc_interactive():
 
     # Branding
     brand_fig(fig, 'THE RISE OF cbBTC', 'Coinbase Wrapped BTC Supply Growth', source='DefiLlama')
-    add_annotation_box(ax, "From $0 to $6B in 18 months  |  Capital rotating to productive collateral", x=0.5, y=0.88)
+    add_annotation_box(ax, "From $0 to $6B in 18 months  |  Capital rotating to productive collateral")
 
     # Margins and border
     fig.subplots_adjust(top=0.86, bottom=0.10, left=0.08, right=0.94)

--- a/Scripts/chart_generation/business_edu_charts.py
+++ b/Scripts/chart_generation/business_edu_charts.py
@@ -12,6 +12,7 @@ Usage:
 """
 
 import os
+import textwrap
 import argparse
 import time
 import ssl
@@ -277,8 +278,45 @@ def style_single_ax(ax, fmt='{:.1f}%'):
     ax.yaxis.set_major_formatter(FuncFormatter(lambda x, p: fmt.format(x)))
 
 
-def add_annotation_box(ax, text, x=0.52, y=0.92):
-    """Add takeaway annotation box in dead space."""
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     # Dark theme: Ocean fill at 20% to pop against chart bg
     # White theme: keep chart bg
     box_fc = '#2389BB'
@@ -492,8 +530,7 @@ def chart_01():
     regime = "expansion" if pmi_last > 50 else "contraction"
     add_annotation_box(ax,
         f"ISM Manufacturing at {pmi_last:.1f} ({regime}).\n"
-        f"Below 50 = contraction. Below 45 = deep recession signal.",
-        x=0.70, y=0.92)
+        f"Below 50 = contraction. Below 45 = deep recession signal.")
 
     brand_fig(fig, 'ISM Manufacturing PMI',
               subtitle='The earliest read on goods economy health',
@@ -554,8 +591,7 @@ def chart_02():
     spread_last_val = mfg.iloc[-1] - svc.iloc[-1]  # just for annotation
     add_annotation_box(ax_top,
         f"Manufacturing leads down by 6-9 months. Services follows.\n"
-        f"Gap narrows as cycles mature.",
-        x=0.58, y=0.12)
+        f"Gap narrows as cycles mature.")
 
     # === BOTTOM PANEL: Services - Manufacturing spread ===
     combined = pd.DataFrame({'mfg': mfg, 'svc': svc}).dropna()
@@ -632,8 +668,7 @@ def chart_03():
     add_annotation_box(ax,
         f"New Orders lead PMI by 1-2 months. Employment lags.\n"
         f"Orders {no_last:.1f}, Employment {emp_last:.1f}. "
-        f"{'Employment contracting.' if emp_last < 50 else 'Employment expanding.'}",
-        x=0.52, y=0.15)
+        f"{'Employment contracting.' if emp_last < 50 else 'Employment expanding.'}")
 
     brand_fig(fig, 'ISM Manufacturing Subcomponents',
               subtitle='New Orders lead. Employment confirms. Prices signal inflation.',
@@ -678,8 +713,7 @@ def chart_04():
     spread = orders_last - ships_last
     add_annotation_box(ax,
         f"Orders {orders_last:+.1f}% vs Shipments {ships_last:+.1f}%.\n"
-        f"Spread: {spread:+.1f}pp. Negative = backlog shrinking.",
-        x=0.80, y=0.94)
+        f"Spread: {spread:+.1f}pp. Negative = backlog shrinking.")
 
     brand_fig(fig, 'Core Capital Goods: Orders vs Shipments',
               subtitle='The Forward Commitment: CEOs voting with their checkbooks',
@@ -739,8 +773,7 @@ def chart_05():
     status = "shrinking" if last_val < 1.0 else "growing"
     add_annotation_box(ax,
         f"Ratio at {last_val:.2f}x. Backlog {status}.\n"
-        f"Below 0.95x = demand weaker than supply. Orders drying up.",
-        x=0.78, y=0.98)
+        f"Below 0.95x = demand weaker than supply. Orders drying up.")
 
     brand_fig(fig, 'Core Capital Goods: Bookings/Billings Ratio',
               subtitle='When orders lag shipments, the backlog is dying',
@@ -781,8 +814,7 @@ def chart_06():
     ext_last = ex_transport.iloc[-1]
     add_annotation_box(ax,
         f"Total durables: {total_last:+.1f}% YoY. Ex-transport: {ext_last:+.1f}%.\n"
-        f"Ex-transport strips Boeing volatility. The cleaner trend signal.",
-        x=0.52, y=0.92)
+        f"Ex-transport strips Boeing volatility. The cleaner trend signal.")
 
     brand_fig(fig, 'Durable Goods Orders: Total vs Ex-Transportation',
               subtitle='Stripping Boeing noise reveals the underlying trend',
@@ -853,8 +885,7 @@ def chart_07():
     status = "elevated" if is_last > 1.38 else "balanced"
     add_annotation_box(ax1,
         f"I/S ratio at {is_last:.2f} ({status}). Threshold: 1.40.\n"
-        f"When inventories build faster than sales, production cuts follow.",
-        x=0.52, y=0.92)
+        f"When inventories build faster than sales, production cuts follow.")
 
     brand_fig(fig, 'Business Inventories & Inventory/Sales Ratio',
               subtitle='The Mistake Detector: overstock signals liquidation ahead',
@@ -924,8 +955,7 @@ def chart_08():
     signal = "contraction" if avg_last < 0 else "expansion"
     add_annotation_box(ax,
         f"5-survey average at {avg_last:.1f} ({signal}).\n"
-        f"Regional surveys preview ISM by 2-3 weeks. Below zero = manufacturing shrinking.",
-        x=0.45, y=0.13)
+        f"Regional surveys preview ISM by 2-3 weeks. Below zero = manufacturing shrinking.")
 
     brand_fig(fig, 'Regional Fed Manufacturing Surveys',
               subtitle='ISM Preview: five districts tell one story',
@@ -1003,8 +1033,7 @@ def chart_09():
     slack = "building" if cu_last < 78 else "tight"
     add_annotation_box(ax1,
         f"IP growth: {ip_last:+.1f}% YoY. Capacity util: {cu_last:.1f}% (slack {slack}).\n"
-        f"Below 78% = slack in system. Pricing power falls, disinflation follows.",
-        x=0.62, y=0.96)
+        f"Below 78% = slack in system. Pricing power falls, disinflation follows.")
 
     brand_fig(fig, 'Industrial Production & Manufacturing Capacity Utilization',
               subtitle='Production output meets the capacity constraint',
@@ -1049,8 +1078,7 @@ def chart_10():
     status = "growing" if p_last > 0 else "contracting"
     add_annotation_box(ax,
         f"Corporate profits {status} at {p_last:+.1f}% YoY.\n"
-        f"Margin compression precedes layoffs by 2-4 quarters.",
-        x=0.52, y=0.92)
+        f"Margin compression precedes layoffs by 2-4 quarters.")
 
     brand_fig(fig, 'Corporate Profits: Year-Over-Year Growth',
               subtitle='The Bottom Line: profits peak before the economy does',
@@ -1101,8 +1129,7 @@ def chart_11():
     pressure = "Margins under pressure" if gap > 0 else "Margins expanding"
     add_annotation_box(ax,
         f"ULC {ulc_last:+.1f}% vs Productivity {prod_last:+.1f}%. Gap: {gap:+.1f}pp.\n"
-        f"{pressure}. When labor costs outrun productivity, layoffs follow.",
-        x=0.72, y=0.92)
+        f"{pressure}. When labor costs outrun productivity, layoffs follow.")
 
     subtitle = ('The Margin Squeeze: labor costs eating into profits'
                 if gap > 0
@@ -1171,8 +1198,7 @@ def chart_12():
     delinq_last = delinq.iloc[-1]
     add_annotation_box(ax1,
         f"Loan growth: {loans_last:+.1f}% YoY. Delinquency: {delinq_last:.1f}%.\n"
-        f"When growth declines and delinquency rises, the credit cycle turns.",
-        x=0.52, y=0.92)
+        f"When growth declines and delinquency rises, the credit cycle turns.")
 
     brand_fig(fig, 'Business Loan Growth & Delinquency Rate',
               subtitle='The Credit Channel: banks tighten as stress builds',
@@ -1216,8 +1242,7 @@ def chart_13():
     lei_last = lei_yoy.iloc[-1]
     add_annotation_box(ax,
         f"LEI {lei_last:+.1f}% YoY. Below -4% for 6+ months = recession.\n"
-        f"Composite of 10 leading indicators: the economy's crystal ball.",
-        x=0.72, y=0.95)
+        f"Composite of 10 leading indicators: the economy's crystal ball.")
 
     brand_fig(fig, 'Conference Board Leading Economic Index',
               subtitle='10 indicators, one signal: where the economy is heading',

--- a/Scripts/chart_generation/consumer_edu_charts.py
+++ b/Scripts/chart_generation/consumer_edu_charts.py
@@ -12,6 +12,7 @@ Usage:
 """
 
 import os
+import textwrap
 import argparse
 import time
 import ssl
@@ -229,8 +230,45 @@ def style_single_ax(ax):
     ax.yaxis.set_major_formatter(FuncFormatter(lambda x, p: f'{x:.1f}%'))
 
 
-def add_annotation_box(ax, text, x=0.52, y=0.92):
-    """Add takeaway annotation box in dead space."""
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     ax.text(x, y, text, transform=ax.transAxes,
             fontsize=10, color=THEME['fg'], ha='center', va='top',
             style='italic',
@@ -411,8 +449,7 @@ def chart_01():
     pce_last = pce.iloc[-1]
     gap = dpi_last - pce_last
     add_annotation_box(ax,
-        f"Income-Spending Gap: {gap:+.1f}pp.\nWhen spending exceeds income, credit fills the gap.",
-        x=0.52, y=0.92)
+        f"Income-Spending Gap: {gap:+.1f}pp.\nWhen spending exceeds income, credit fills the gap.")
 
     brand_fig(fig, 'Real Disposable Income vs Real Consumer Spending',
               subtitle='Income vs Credit: Which is driving spending?',
@@ -463,8 +500,7 @@ def chart_02():
     dur_last = durables.iloc[-1]
     svc_last = services.iloc[-1]
     add_annotation_box(ax,
-        f"Durables at {dur_last:.1f}% YoY, Services at {svc_last:.1f}%.\nDurables turn first at cycle inflections.",
-        x=0.52, y=0.92)
+        f"Durables at {dur_last:.1f}% YoY, Services at {svc_last:.1f}%.\nDurables turn first at cycle inflections.")
 
     brand_fig(fig, 'Personal Consumption Expenditures: Component Breakdown',
               subtitle='Durables lead the cycle, Services lag',
@@ -524,8 +560,7 @@ def chart_03():
     dur_last = durables.iloc[-1]
     svc_last = services.iloc[-1]
     add_annotation_box(ax1,
-        f"Durables ({dur_last:.1f}%) turn before Services ({svc_last:.1f}%).\nThe cyclical canary in the consumer coal mine.",
-        x=0.52, y=0.98)
+        f"Durables ({dur_last:.1f}%) turn before Services ({svc_last:.1f}%).\nThe cyclical canary in the consumer coal mine.")
 
     brand_fig(fig, 'Durable Goods vs Services Spending',
               subtitle='Durables turn first at cycle inflections',
@@ -580,8 +615,7 @@ def chart_04():
 
     sav_last = saving.iloc[-1]
     add_annotation_box(ax,
-        f"Saving rate at {sav_last:.1f}%. Pre-pandemic normal: 7.5%.\nExcess savings depleted by Q1 2024 per SF Fed.",
-        x=0.35, y=0.92)
+        f"Saving rate at {sav_last:.1f}%. Pre-pandemic normal: 7.5%.\nExcess savings depleted by Q1 2024 per SF Fed.")
 
     brand_fig(fig, 'Personal Saving Rate',
               subtitle='The fuel tank is running low',
@@ -637,8 +671,7 @@ def chart_05():
 
     rev_last = revolving.iloc[-1]
     add_annotation_box(ax1,
-        f"Revolving credit growing {rev_last:.1f}% YoY.\nCredit substituting for depleted savings.",
-        x=0.52, y=0.12)
+        f"Revolving credit growing {rev_last:.1f}% YoY.\nCredit substituting for depleted savings.")
 
     brand_fig(fig, 'Consumer Credit Growth: Revolving vs Nonrevolving',
               subtitle='Credit cards fill the gap when savings run dry',
@@ -690,8 +723,7 @@ def chart_06():
 
     dq_last = dq.iloc[-1]
     add_annotation_box(ax,
-        f"CC delinquency at {dq_last:.1f}%. Peaked ~3.2% Q2 2024.\nNY Fed Q4 2025: aggregate delinquency re-accelerating.",
-        x=0.62, y=0.92)
+        f"CC delinquency at {dq_last:.1f}%. Peaked ~3.2% Q2 2024.\nNY Fed Q4 2025: aggregate delinquency re-accelerating.")
 
     brand_fig(fig, 'Credit Card Delinquency Rate',
               subtitle='When savings run out, credit stress builds',
@@ -743,8 +775,7 @@ def chart_07():
 
     u_last = umich.iloc[-1]
     add_annotation_box(ax,
-        f"Sentiment at {u_last:.0f}.\nSustained readings below 65 historically\nprecede or coincide with recessions.",
-        x=0.55, y=0.98)
+        f"Sentiment at {u_last:.0f}.\nSustained readings below 65 historically\nprecede or coincide with recessions.")
 
     brand_fig(fig, 'University of Michigan Consumer Sentiment',
               subtitle='Confidence leads spending by 1-3 months',
@@ -809,8 +840,7 @@ def chart_08():
     nom_last = common['nominal'].iloc[-1]
     real_last = common['real'].iloc[-1]
     add_annotation_box(ax,
-        f"Aggregate payrolls: {nom_last:.1f}% nominal, {real_last:.1f}% real.\nEmployment x Hours x Wages = total income.",
-        x=0.55, y=0.98)
+        f"Aggregate payrolls: {nom_last:.1f}% nominal, {real_last:.1f}% real.\nEmployment x Hours x Wages = total income.")
 
     brand_fig(fig, 'Aggregate Weekly Payrolls (Employment x Hours x Wages)',
               subtitle='The paycheck reality behind consumer spending',
@@ -854,8 +884,7 @@ def chart_09():
 
     dsr_last = dsr.iloc[-1]
     add_annotation_box(ax,
-        f"DSR at {dsr_last:.1f}% of disposable income.\nRising rates push payments higher even\nwithout new borrowing.",
-        x=0.55, y=0.92)
+        f"DSR at {dsr_last:.1f}% of disposable income.\nRising rates push payments higher even\nwithout new borrowing.")
 
     brand_fig(fig, 'Household Debt Service Ratio',
               subtitle='Payment burden as share of disposable income',
@@ -913,8 +942,7 @@ def chart_10():
 
     ratio_last = common['ratio'].iloc[-1]
     add_annotation_box(ax,
-        f"NW/DPI at {ratio_last:.1f}x.\nAggregate looks strong, but top 10% hold ~68%\nof wealth. Bottom 50% have negative net worth.",
-        x=0.52, y=0.98)
+        f"NW/DPI at {ratio_last:.1f}x.\nAggregate looks strong, but top 10% hold ~68%\nof wealth. Bottom 50% have negative net worth.")
 
     brand_fig(fig, 'Household Net Worth to Disposable Income',
               subtitle='Aggregate wealth masks distributional reality',
@@ -1014,8 +1042,7 @@ def chart_11():
     else: regime = "Crisis"
 
     add_annotation_box(ax,
-        f"CCI at {cci_last:.2f}: {regime} regime.\nPCE, savings, credit, confidence, income, debt service.",
-        x=0.35, y=0.92)
+        f"CCI at {cci_last:.2f}: {regime} regime.\nPCE, savings, credit, confidence, income, debt service.")
 
     brand_fig(fig, 'Consumer Composite Index (CCI)',
               subtitle='Synthesizing consumer health into one regime indicator',

--- a/Scripts/chart_generation/fig11_adp_firm_size_march2026.py
+++ b/Scripts/chart_generation/fig11_adp_firm_size_march2026.py
@@ -101,9 +101,7 @@ def fig11_march2026_yoy():
 
     add_annotation_box(
         ax,
-        'Composition has flipped since January.\nSmall firms back to growth, medium firms still shedding.',
-        x=0.50, y=0.92
-    )
+        'Composition has flipped since January.\nSmall firms back to growth, medium firms still shedding.')
 
     brand_fig(
         fig,

--- a/Scripts/chart_generation/fig12_adp_turnover_march2026.py
+++ b/Scripts/chart_generation/fig12_adp_turnover_march2026.py
@@ -68,7 +68,6 @@ def fig12_turnover():
         ax,
         "Small-employer turnover at 3.9% — a 9-year low.\n"
         "Workers stopped quitting. The labor market froze.",
-        x=0.50, y=0.95,
     )
 
     brand_fig(

--- a/Scripts/chart_generation/financial_edu_charts.py
+++ b/Scripts/chart_generation/financial_edu_charts.py
@@ -17,6 +17,7 @@ Usage:
 """
 
 import os
+import textwrap
 import argparse
 import time
 import ssl
@@ -299,12 +300,45 @@ def style_single_ax(ax, fmt='{:.1f}%'):
     ax.yaxis.set_major_formatter(FuncFormatter(lambda x, p: fmt.format(x)))
 
 
-def add_annotation_box(ax, text, x=0.50, y=0.95):
-    """Add takeaway annotation box at specified position.
 
-    Default is bottom-center which avoids data on most time series charts.
-    Each chart caller should pass x,y explicitly based on where the dead space is.
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
     """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     box_fc = '#2389BB'
     txt_color = '#ffffff'
     ax.text(x, y, text, transform=ax.transAxes,
@@ -500,8 +534,7 @@ def chart_01():
     add_annotation_box(ax,
         f"Current: {last_val:.0f} bps ({pctile:.0f}th percentile)\n"
         f"20-year rolling distribution context.\n"
-        f"Percentile tells you where we stand in history.",
-        x=0.50, y=0.95)
+        f"Percentile tells you where we stand in history.")
 
     brand_fig(fig, 'High-Yield Credit Spreads',
               subtitle='ICE BofA HY OAS | Percentile Distribution (20-Year Rolling)',
@@ -701,8 +734,7 @@ def chart_04():
     add_annotation_box(ax,
         "The headline hides the war.\n"
         "Subcomponents can diverge sharply.\n"
-        "Credit subindex leads the composite.",
-        x=0.50, y=0.95)
+        "Credit subindex leads the composite.")
 
     brand_fig(fig, 'Financial Conditions: The Headline Hides the War',
               subtitle='NFCI Composite vs. Risk, Credit, and Leverage Subindices',
@@ -780,8 +812,7 @@ def chart_05():
     add_annotation_box(ax1,
         "When banks tighten (SLOOS drops inverted),\n"
         "loan growth follows 2-4 quarters later.\n"
-        "SLOOS is the pipeline. Loans are the flow.",
-        x=0.50, y=0.98)
+        "SLOOS is the pipeline. Loans are the flow.")
 
     brand_fig(fig, 'The Credit Pipeline: When Banks Tighten, Loan Growth Follows',
               subtitle='SLOOS C&I Tightening (Inverted, Leading) vs. C&I Loan Growth YoY',
@@ -844,8 +875,7 @@ def chart_06():
     add_annotation_box(ax1,
         "When these diverge, policy is not transmitting.\n"
         "Real rates restrictive + spreads tight =\n"
-        "the market is overriding the Fed.",
-        x=0.50, y=0.05)
+        "the market is overriding the Fed.")
 
     brand_fig(fig, 'The Transmission Gap',
               subtitle='Real Rates (Restrictive) vs. HY Spreads (Inverted, Loose)',
@@ -912,8 +942,7 @@ def chart_07():
     add_annotation_box(ax1,
         "When VVIX rises faster than VIX,\n"
         "dealers are hedging tail risk.\n"
-        "The vol market sees something equity doesn't.",
-        x=0.50, y=0.95)
+        "The vol market sees something equity doesn't.")
 
     brand_fig(fig, 'The Vol Signal: VIX vs. VVIX',
               subtitle='Equity Implied Volatility vs. Vol-of-Vol | Tail Risk Detection',
@@ -1108,8 +1137,7 @@ def chart_10():
     add_annotation_box(ax,
         "Rising ratio = market differentiating quality.\n"
         "When HY widens faster than IG, risk\n"
-        "repricing is underway. Spikes precede crises.",
-        x=0.50, y=0.95)
+        "repricing is underway. Spikes precede crises.")
 
     brand_fig(fig, 'Credit Quality Differentiation',
               subtitle='HY OAS / IG OAS Ratio | When the Market Starts Discriminating',
@@ -1303,8 +1331,7 @@ def chart_12():
     add_annotation_box(ax,
         "All three below zero: stress is muted.\n"
         "Watch for convergence above zero.\n"
-        "That is when isolated becomes systemic.",
-        x=0.50, y=0.95)
+        "That is when isolated becomes systemic.")
 
     brand_fig(fig, 'Financial Stress Convergence',
               subtitle='Three Public Stress Signals Normalized | Baa-10Y, NFCI, VIX',
@@ -1371,8 +1398,7 @@ def chart_13():
     add_annotation_box(ax,
         "Nearly half of all 'investment grade' bonds\n"
         "are one downgrade from junk.\n"
-        "The cliff is structural, not cyclical.",
-        x=0.50, y=0.95)
+        "The cliff is structural, not cyclical.")
 
     brand_fig(fig, 'The BBB Cliff',
               subtitle='BBB Share of Investment-Grade Universe | The Fallen Angel Risk',

--- a/Scripts/chart_generation/financial_edu_charts_interactive.ipynb
+++ b/Scripts/chart_generation/financial_edu_charts_interactive.ipynb
@@ -65,7 +65,7 @@
     "add_last_value_label(ax, hy_bps, color=THEME['primary'], fmt='{:.0f}', side='right')\n",
     "add_recessions(ax, start_date='1997-01-01')\n",
     "ax.legend(loc='upper right', fontsize=9, **legend_style())\n",
-    "add_annotation_box(ax, f'Current: {last_val:.0f} bps ({pctile:.0f}th pctile)\\n20-year rolling distribution.', x=ann_x, y=ann_y)\n",
+    "add_annotation_box(ax, f'Current: {last_val:.0f} bps ({pctile:.0f}th pctile)\\n20-year rolling distribution.')\n",
     "brand_fig(fig, 'High-Yield Credit Spreads', subtitle='ICE BofA HY OAS | Percentile Distribution', source='ICE BofA via FRED', data_date=hy_bps.index[-1])\n",
     "plt.show()"
    ]
@@ -96,7 +96,7 @@
     "add_last_value_label(ax, nfci, color=THEME['primary'], fmt='{:.2f}', side='right')\n",
     "add_recessions(ax, start_date='1999-01-01')\n",
     "ax.legend(loc='upper right', fontsize=9, **legend_style())\n",
-    "add_annotation_box(ax, 'The headline hides the war.\\nSubcomponents can diverge sharply.', x=ann_x, y=ann_y)\n",
+    "add_annotation_box(ax, 'The headline hides the war.\\nSubcomponents can diverge sharply.')\n",
     "brand_fig(fig, 'NFCI Decomposition', subtitle='Composite vs Subindices', source='Chicago Fed via FRED', data_date=nfci.index[-1])\n",
     "plt.show()"
    ]
@@ -133,7 +133,7 @@
     "h1, l1 = ax1.get_legend_handles_labels()\n",
     "h2, l2 = ax2.get_legend_handles_labels()\n",
     "ax1.legend(h1+h2, l1+l2, loc='lower left', fontsize=9, **legend_style())\n",
-    "add_annotation_box(ax1, 'SLOOS leads loan growth 2-4 quarters.\\nThe pipeline is the signal.', x=ann_x, y=ann_y)\n",
+    "add_annotation_box(ax1, 'SLOOS leads loan growth 2-4 quarters.\\nThe pipeline is the signal.')\n",
     "brand_fig(fig, 'The Credit Pipeline', subtitle='SLOOS vs C&I Loan Growth', source='Federal Reserve via FRED', data_date=sloos_inv.index[-1])\n",
     "plt.show()"
    ]
@@ -168,7 +168,7 @@
     "h1, l1 = ax1.get_legend_handles_labels()\n",
     "h2, l2 = ax2.get_legend_handles_labels()\n",
     "ax1.legend(h1+h2, l1+l2, loc='upper right', fontsize=9, **legend_style())\n",
-    "add_annotation_box(ax1, 'When these diverge, policy\\nis not transmitting.', x=ann_x, y=ann_y)\n",
+    "add_annotation_box(ax1, 'When these diverge, policy\\nis not transmitting.')\n",
     "brand_fig(fig, 'The Transmission Gap', subtitle='Real Rates vs HY Spreads (Inverted)', source='FRED, ICE BofA', data_date=real_rate.index[-1])\n",
     "plt.show()"
    ]
@@ -200,7 +200,7 @@
     "h1, l1 = ax1.get_legend_handles_labels()\n",
     "h2, l2 = ax2.get_legend_handles_labels()\n",
     "ax1.legend(h1+h2, l1+l2, loc='upper right', fontsize=9, **legend_style())\n",
-    "add_annotation_box(ax1, 'When VVIX rises faster than VIX,\\ndealers are hedging tail risk.', x=ann_x, y=ann_y)\n",
+    "add_annotation_box(ax1, 'When VVIX rises faster than VIX,\\ndealers are hedging tail risk.')\n",
     "brand_fig(fig, 'VIX vs VVIX', subtitle='Tail Risk Detection', source='CBOE via FRED', data_date=vix.index[-1])\n",
     "plt.show()"
    ]
@@ -230,7 +230,7 @@
     "add_last_value_label(ax, ratio, color=THEME['primary'], fmt='{:.1f}x', side='right')\n",
     "add_recessions(ax, start_date='1997-01-01')\n",
     "ax.legend(loc='upper right', fontsize=9, **legend_style())\n",
-    "add_annotation_box(ax, 'Rising ratio = market differentiating.\\nSpikes precede crises.', x=ann_x, y=ann_y)\n",
+    "add_annotation_box(ax, 'Rising ratio = market differentiating.\\nSpikes precede crises.')\n",
     "brand_fig(fig, 'Credit Quality Differentiation', subtitle='HY/IG Ratio', source='ICE BofA via FRED', data_date=ratio.index[-1])\n",
     "plt.show()"
    ]
@@ -269,7 +269,7 @@
     "add_recessions(ax, start_date='2000-01-01')\n",
     "ax.legend(loc='upper left', fontsize=9, **legend_style())\n",
     "add_last_value_label(ax, baa_z, color=COLORS['ocean'], fmt='{:.1f}', side='right')\n",
-    "add_annotation_box(ax, 'Convergence above zero = broad stress.\\nDivergence = isolated.', x=ann_x, y=ann_y)\n",
+    "add_annotation_box(ax, 'Convergence above zero = broad stress.\\nDivergence = isolated.')\n",
     "brand_fig(fig, 'Stress Convergence', subtitle='3 Public Signals Normalized', source='Chicago Fed, CBOE, Moody\\'s via FRED', data_date=baa_z.index[-1])\n",
     "plt.show()"
    ]

--- a/Scripts/chart_generation/government_edu_charts.py
+++ b/Scripts/chart_generation/government_edu_charts.py
@@ -15,6 +15,7 @@ Usage:
 """
 
 import os
+import textwrap
 import argparse
 import time
 import ssl
@@ -257,8 +258,45 @@ def style_single_ax(ax, fmt='{:.1f}%'):
     ax.yaxis.set_major_formatter(FuncFormatter(lambda x, p: fmt.format(x)))
 
 
-def add_annotation_box(ax, text, x=0.52, y=0.92):
-    """Add takeaway annotation box in dead space."""
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     box_fc = '#2389BB'
     box_alpha = 1.0
     txt_color = '#ffffff'
@@ -446,8 +484,7 @@ def chart_01():
     add_annotation_box(ax,
         f"Running {abs(deficit.iloc[-1]):.0f}% of GDP deficits\n"
         f"outside of recession.\n"
-        f"This is structural, not cyclical.",
-        x=0.50, y=0.18)
+        f"This is structural, not cyclical.")
 
     brand_fig(fig, 'Federal Surplus/Deficit as % of GDP',
               subtitle='Structural deficits at full employment',
@@ -499,8 +536,7 @@ def chart_02():
     add_annotation_box(ax,
         "Term premium is the 'honest signal.'\n"
         "Post-QE suppression is normalizing.\n"
-        "Still below what structural deficits demand.",
-        x=0.50, y=0.93)
+        "Still below what structural deficits demand.")
 
     brand_fig(fig, 'ACM 10-Year Term Premium',
               subtitle='The honest signal of fiscal sustainability',
@@ -559,8 +595,7 @@ def chart_03():
     add_annotation_box(ax1,
         "A 4.5% yield driven by rate expectations\n"
         "is different from 4.5% driven by term premium.\n"
-        "The composition shift is the story.",
-        x=0.52, y=0.92)
+        "The composition shift is the story.")
 
     brand_fig(fig, '10-Year Yield Decomposition',
               subtitle='Expected rate vs. term premium: what is driving yields?',
@@ -604,8 +639,7 @@ def chart_04():
     add_annotation_box(ax,
         "Interest as a share of revenue is rising\n"
         "back toward early-1990s peaks.\n"
-        "The compounding trap is real.",
-        x=0.52, y=0.25)
+        "The compounding trap is real.")
 
     brand_fig(fig, 'Federal Interest Expense as % of Revenue',
               subtitle='The compounding trap: higher rates on a larger debt stock',
@@ -643,8 +677,7 @@ def chart_05():
     add_annotation_box(ax,
         "Interest payments have surpassed\n"
         "defense spending. Approaching $1T annually.\n"
-        "This is the doom loop in action.",
-        x=0.35, y=0.92)
+        "This is the doom loop in action.")
 
     brand_fig(fig, 'Federal Government Interest Outlays',
               subtitle='Now larger than defense spending',
@@ -687,8 +720,7 @@ def chart_06():
     add_annotation_box(ax,
         f"Debt-to-GDP at {debt_gdp.iloc[-1]:.0f}%.\n"
         f"Highest since WWII, but trajectory\n"
-        f"is the real concern: 120%+ by 2030.",
-        x=0.52, y=0.93)
+        f"is the real concern: 120%+ by 2030.")
 
     brand_fig(fig, 'Federal Debt as % of GDP',
               subtitle='The level matters less than the trajectory',
@@ -741,8 +773,7 @@ def chart_07():
     add_annotation_box(ax,
         "Positive = government adding to demand.\n"
         "Negative = fiscal drag on growth.\n"
-        "Spending cuts are contractionary by definition.",
-        x=0.52, y=0.92)
+        "Spending cuts are contractionary by definition.")
 
     brand_fig(fig, 'Fiscal Impulse: Year-Over-Year Change in Deficit',
               subtitle='The second derivative of government spending',
@@ -819,8 +850,7 @@ def chart_08():
     add_annotation_box(ax,
         f"GCI-Gov at {gcigov.iloc[-1]:.2f}.\n"
         "Positive = fiscal stress rising.\n"
-        "Synthesizes deficit, debt, interest, term premium.",
-        x=0.35, y=0.93)
+        "Synthesizes deficit, debt, interest, term premium.")
 
     brand_fig(fig, 'Government Conditions Index (GCI-Gov)',
               subtitle='Pillar 8 Composite: fiscal stress in a single number',
@@ -866,8 +896,7 @@ def chart_09():
     add_annotation_box(ax,
         "Foreign demand for Treasuries peaked\n"
         "around 2014 and has been declining.\n"
-        "The marginal buyer is now price-sensitive.",
-        x=0.40, y=0.92)
+        "The marginal buyer is now price-sensitive.")
 
     brand_fig(fig, 'Foreign Holdings as Share of Federal Debt',
               subtitle='The marginal buyer has changed',
@@ -928,8 +957,7 @@ def chart_10():
     add_annotation_box(ax,
         f"The gap: ${gap:,.0f}B in annual deficit.\n"
         f"Outlays growing faster than receipts.\n"
-        f"The scissors are opening, not closing.",
-        x=0.40, y=0.45)
+        f"The scissors are opening, not closing.")
 
     brand_fig(fig, 'Federal Receipts vs. Outlays (Trailing 12 Months)',
               subtitle='The structural gap: spending outpaces revenue',

--- a/Scripts/chart_generation/growth_edu_charts.py
+++ b/Scripts/chart_generation/growth_edu_charts.py
@@ -12,6 +12,7 @@ Usage:
 """
 
 import os
+import textwrap
 import argparse
 import time
 import ssl
@@ -227,8 +228,45 @@ def style_single_ax(ax):
     ax.yaxis.set_major_formatter(FuncFormatter(lambda x, p: f'{x:.1f}%'))
 
 
-def add_annotation_box(ax, text, x=0.52, y=0.92):
-    """Add takeaway annotation box in dead space."""
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     ax.text(x, y, text, transform=ax.transAxes,
             fontsize=10, color=THEME['fg'], ha='center', va='top',
             style='italic',
@@ -405,8 +443,7 @@ def chart_01():
     ip_2nd_last = ip_2nd.iloc[-1]
     momentum = "decelerating" if ip_2nd_last < 0 else "accelerating"
     add_annotation_box(ax,
-        f"IP at {ip_last:.1f}% YoY, {momentum}.\nOrange shading = negative second derivative.",
-        x=0.55, y=0.12)
+        f"IP at {ip_last:.1f}% YoY, {momentum}.\nOrange shading = negative second derivative.")
 
     brand_fig(fig, 'Industrial Production: The Second Derivative',
               subtitle='Momentum breaks (shaded) precede level declines',
@@ -456,8 +493,7 @@ def chart_02():
     ax1.legend(lines1 + lines2, labels1 + labels2, loc='upper left', **legend_style())
 
     add_annotation_box(ax1,
-        f"IP ({ip.iloc[-1]:.1f}%) and GDP ({gdp.iloc[-1]:.1f}%) highly correlated (r=0.86).\nIP peaks slightly before GDP at cycle turns.",
-        x=0.50, y=0.92)
+        f"IP ({ip.iloc[-1]:.1f}%) and GDP ({gdp.iloc[-1]:.1f}%) highly correlated (r=0.86).\nIP peaks slightly before GDP at cycle turns.")
 
     brand_fig(fig, 'Industrial Production vs Real GDP',
               subtitle='IP leads GDP by 1-2 quarters at cycle turns',
@@ -518,8 +554,7 @@ def chart_03():
     avg_last = regional_avg.iloc[-1]
     status = "expansion" if avg_last > 0 else "contraction"
     add_annotation_box(ax,
-        f"Regional avg at {avg_last:.1f}: manufacturing in {status}.\nISM (Jan 2026): 52.6, first expansion in 12 months.",
-        x=0.50, y=0.12)
+        f"Regional avg at {avg_last:.1f}: manufacturing in {status}.\nISM (Jan 2026): 52.6, first expansion in 12 months.")
 
     brand_fig(fig, 'Regional Fed Manufacturing Surveys',
               subtitle='Above 0 = expansion (similar to ISM above 50)',
@@ -584,7 +619,7 @@ def chart_04():
     else:
         annotation = (f"Orders at {orders_last:.1f}%, investment at {inv_last:.1f}%.\n"
                       f"Orders lead investment by 3-6 months.")
-    add_annotation_box(ax1, annotation, x=0.60, y=0.15)
+    add_annotation_box(ax1, annotation)
 
     brand_fig(fig, 'Core Capital Goods Orders: CEO Confidence',
               subtitle='Orders lead business investment by 3-6 months',
@@ -626,8 +661,7 @@ def chart_05():
     hours_last = hours.iloc[-1]
     status = "contracting" if hours_last < 0 else "expanding"
     add_annotation_box(ax,
-        f"Aggregate hours at {hours_last:.1f}%: labor input {status}.\nHours decline before headcount cuts.",
-        x=0.50, y=0.12 if hours_last > 0 else 0.92)
+        f"Aggregate hours at {hours_last:.1f}%: labor input {status}.\nHours decline before headcount cuts.")
 
     brand_fig(fig, 'Aggregate Hours Worked: Labor Input',
               subtitle='Hours contract before payrolls decline',
@@ -674,8 +708,7 @@ def chart_06():
     ax1.legend(lines1 + lines2, labels1 + labels2, loc='upper left', **legend_style())
 
     add_annotation_box(ax1,
-        f"Housing starts 3MMA ({starts.iloc[-1]:.1f}%) vs GDP ({gdp.iloc[-1]:.1f}%).\nHousing typically peaks 18-24+ months before recessions.",
-        x=0.57, y=0.20)
+        f"Housing starts 3MMA ({starts.iloc[-1]:.1f}%) vs GDP ({gdp.iloc[-1]:.1f}%).\nHousing typically peaks 18-24+ months before recessions.")
 
     brand_fig(fig, 'Housing Starts: The Long Lead',
               subtitle='Housing peaks 18-24+ months before GDP turns',
@@ -735,8 +768,7 @@ def chart_07():
     # Calculate total to show in annotation
     gdp_total = sum(values)
     add_annotation_box(ax,
-        f"YoY contributions to GDP growth.\nTotal: {gdp_total:+.1f} pp. PCE drives ~68% of GDP.",
-        x=0.52, y=0.92)
+        f"YoY contributions to GDP growth.\nTotal: {gdp_total:+.1f} pp. PCE drives ~68% of GDP.")
 
     brand_fig(fig, 'GDP Component Contributions (YoY)',
               subtitle='What is driving (or dragging) growth? (percentage points)',
@@ -796,8 +828,7 @@ def chart_08():
     s_last = services_plot.iloc[-1]
     spread = s_last - g_last
     add_annotation_box(ax1,
-        f"Goods-services spread: {spread:.1f} ppts.\nGoods turn first; services follow at cycle turns.",
-        x=0.50, y=0.92)
+        f"Goods-services spread: {spread:.1f} ppts.\nGoods turn first; services follow at cycle turns.")
 
     brand_fig(fig, 'The Great Divergence: Goods vs Services',
               subtitle='Goods contract first, services follow',
@@ -846,8 +877,7 @@ def chart_09():
     retail_last = retail_yoy.iloc[-1]
     status = "contracting" if retail_last < 0 else f"growing {retail_last:.1f}%"
     add_annotation_box(ax,
-        f"Real retail sales {status}.\nStrips inflation to show true volume growth.",
-        x=0.50, y=0.12 if retail_last > 2 else 0.92)
+        f"Real retail sales {status}.\nStrips inflation to show true volume growth.")
 
     brand_fig(fig, 'Real Retail Sales: Consumer Demand',
               subtitle='Volume growth after stripping inflation',
@@ -945,8 +975,7 @@ def chart_10():
     else: regime = "Recession"
 
     add_annotation_box(ax,
-        f"GCI at {gci_last:.2f}: {regime} regime.\nSynthesizing IP, capex, hours, housing, retail.",
-        x=0.35, y=0.92)
+        f"GCI at {gci_last:.2f}: {regime} regime.\nSynthesizing IP, capex, hours, housing, retail.")
 
     brand_fig(fig, 'Growth Composite Index (GCI)',
               subtitle='Synthesizing growth signals into one regime indicator',

--- a/Scripts/chart_generation/housing_edu_charts.py
+++ b/Scripts/chart_generation/housing_edu_charts.py
@@ -13,6 +13,7 @@ Usage:
 """
 
 import os
+import textwrap
 import argparse
 import time
 import ssl
@@ -280,8 +281,45 @@ def style_single_ax(ax):
     ax.tick_params(axis='y', labelcolor=THEME['fg'], labelsize=10)
 
 
-def add_annotation_box(ax, text, x=0.52, y=0.92):
-    """Add takeaway annotation box in dead space."""
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     ax.text(x, y, text, transform=ax.transAxes,
             fontsize=10, color=THEME['fg'], ha='center', va='top',
             style='italic',
@@ -441,7 +479,7 @@ def chart_01():
     ax1.legend(loc='upper left', **legend_style())
     ax2.legend(loc='upper right', **legend_style())
 
-    add_annotation_box(ax1, 'Sales cratered as rates doubled.\nBuilders adapted with rate buydowns.', x=0.78, y=0.65)
+    add_annotation_box(ax1, 'Sales cratered as rates doubled.\nBuilders adapted with rate buydowns.')
 
     brand_fig(fig, 'New Home Sales vs. 30-Year Mortgage Rate',
               subtitle='Inverted Rate Axis | 2018-Present',
@@ -482,7 +520,7 @@ def chart_02():
     add_recessions(ax, start_date='2019-01-01')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'Sun Belt cooled sharply. Northeast resilient.', x=0.72, y=0.85)
+    add_annotation_box(ax, 'Sun Belt cooled sharply. Northeast resilient.')
 
     brand_fig(fig, 'Regional Home Prices: Case-Shiller City Indices',
               subtitle='Year-over-Year % Change',
@@ -519,7 +557,7 @@ def chart_03():
     add_last_value_label(ax, new, color=THEME['primary'], fmt='{:,.0f}K')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'Builders recovered via rate buydowns\nwhile resale market stays frozen.', x=0.45, y=0.93)
+    add_annotation_box(ax, 'Builders recovered via rate buydowns\nwhile resale market stays frozen.')
 
     brand_fig(fig, 'New Home Sales: Builders Filling the Void',
               subtitle='Seasonally Adjusted Annual Rate (Thousands) | 2005-Present',
@@ -558,7 +596,7 @@ def chart_04():
     ax1.legend(loc='upper left', **legend_style())
     ax2.legend(loc='upper right', **legend_style())
 
-    add_annotation_box(ax1, 'Rates doubled but debt service stayed\nbelow 2007 peak. Lock-in effect at work.', x=0.55, y=0.80)
+    add_annotation_box(ax1, 'Rates doubled but debt service stayed\nbelow 2007 peak. Lock-in effect at work.')
 
     brand_fig(fig, 'Mortgage Rate vs. Debt Service Burden',
               subtitle='Mortgage Payments as % of Disposable Income | 2005-Present',
@@ -603,7 +641,7 @@ def chart_05():
     ax.yaxis.set_major_formatter(FuncFormatter(lambda x, p: f'${x:,.0f}'))
     ax.set_ylim(0, max(payments) * 1.15)
 
-    add_annotation_box(ax, f'44% payment increase from 3% to 6.1%.\n$317,600 loan (median home, 20% down).', x=0.3, y=0.88)
+    add_annotation_box(ax, f'44% payment increase from 3% to 6.1%.\n$317,600 loan (median home, 20% down).')
 
     brand_fig(fig, 'Monthly Mortgage Payment by Rate',
               subtitle='Median Home ($397K) | 20% Down | 30-Year Fixed',
@@ -641,7 +679,7 @@ def chart_06():
     add_recessions(ax, start_date='2015-01-01')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'SF drives the cycle.\nMF a fraction of total.', x=0.87, y=0.93)
+    add_annotation_box(ax, 'SF drives the cycle.\nMF a fraction of total.')
 
     brand_fig(fig, 'Housing Starts: Single-Family vs. Multi-Family',
               subtitle='Thousands of Units, SAAR',
@@ -673,7 +711,7 @@ def chart_07():
     add_recessions(ax, start_date='2015-01-01')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'South = 50%+ of all construction.\nRegional divergence matters.', x=0.7, y=0.55)
+    add_annotation_box(ax, 'South = 50%+ of all construction.\nRegional divergence matters.')
 
     brand_fig(fig, 'Housing Starts by Region',
               subtitle='Thousands of Units, SAAR',
@@ -705,7 +743,7 @@ def chart_08():
     add_last_value_label(ax, permits, color=THEME['primary'], fmt='{:,.0f}K')
     add_last_value_label(ax, starts, color=THEME['secondary'], fmt='{:,.0f}K')
     ax.legend(loc='upper left', **legend_style())
-    add_annotation_box(ax, "Permits lead starts by 1-2 months.\nGap = future supply pipeline.", x=0.85, y=0.90)
+    add_annotation_box(ax, "Permits lead starts by 1-2 months.\nGap = future supply pipeline.")
 
     brand_fig(fig, 'Building Permits vs. Housing Starts',
               subtitle='The Construction Pipeline',
@@ -736,7 +774,7 @@ def chart_09():
     add_last_value_label(ax, comp, color=THEME['secondary'], fmt='{:,.0f}K')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'Under construction peaked mid-2023.\nCompletions catching up.', x=0.8, y=0.40)
+    add_annotation_box(ax, 'Under construction peaked mid-2023.\nCompletions catching up.')
 
     brand_fig(fig, 'Housing Units Under Construction vs. Completions',
               subtitle='Thousands of Units, SAAR',
@@ -771,7 +809,7 @@ def chart_10():
     add_last_value_label(ax, national, color=THEME['primary'], fmt='{:.1f}%')
     add_last_value_label(ax, city20, color=THEME['secondary'], fmt='{:.1f}%')
     ax.legend(loc='upper left', **legend_style())
-    add_annotation_box(ax, 'Low single-digit appreciation.\nTight supply supporting prices.', x=0.78, y=0.88)
+    add_annotation_box(ax, 'Low single-digit appreciation.\nTight supply supporting prices.')
 
     brand_fig(fig, 'Case-Shiller Home Price Index',
               subtitle='National vs. 20-City Composite | Year-over-Year %',
@@ -807,7 +845,7 @@ def chart_11():
     add_recessions(ax, start_date='2005-01-01')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'FHFA broader coverage (conforming loans).\nCase-Shiller: repeat-sales methodology.', x=0.3, y=0.15)
+    add_annotation_box(ax, 'FHFA broader coverage (conforming loans).\nCase-Shiller: repeat-sales methodology.')
 
     brand_fig(fig, 'Case-Shiller vs. FHFA House Price Index',
               subtitle='Year-over-Year % Change | Two Measurement Approaches',
@@ -848,7 +886,7 @@ def chart_12():
     add_last_value_label(ax, combined['real'], color=THEME['secondary'], fmt='{:.1f}%')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'Real flat-to-negative = affordability\nimproving without a crash.', x=0.7, y=0.15)
+    add_annotation_box(ax, 'Real flat-to-negative = affordability\nimproving without a crash.')
 
     brand_fig(fig, 'Nominal vs. Real Home Price Appreciation',
               subtitle='Case-Shiller YoY% Minus CPI YoY%',
@@ -970,7 +1008,7 @@ def chart_15():
     add_last_value_label(ax, dq, color=THEME['secondary'], fmt='{:.2f}%')
     ax.legend(loc='upper right', **legend_style())
 
-    add_annotation_box(ax, 'Not 2008. Credit channel is not engaged.\nBorrower profiles historically strong.', x=0.65, y=0.75)
+    add_annotation_box(ax, 'Not 2008. Credit channel is not engaged.\nBorrower profiles historically strong.')
 
     brand_fig(fig, 'Mortgage Delinquency Rate (30+ Days)',
               subtitle='Single-Family Residential | All Commercial Banks',
@@ -1078,7 +1116,7 @@ def chart_18():
     add_last_value_label(ax, shelter, color=THEME['primary'], fmt='{:.1f}%')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'Shelter = 34% of CPI, 18% of Core PCE.\nMarket rents lead by 12-18 months.', x=0.5, y=0.45)
+    add_annotation_box(ax, 'Shelter = 34% of CPI, 18% of Core PCE.\nMarket rents lead by 12-18 months.')
 
     brand_fig(fig, 'CPI Shelter Inflation Components',
               subtitle='Year-over-Year % | Shelter, Rent, and OER',
@@ -1109,7 +1147,7 @@ def chart_19():
     add_last_value_label(ax, new_price / 1000, color=THEME['secondary'], fmt='${:.0f}K')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'New home premium narrowing.\nBuilders cutting to sustain volume.', x=0.35, y=0.55)
+    add_annotation_box(ax, 'New home premium narrowing.\nBuilders cutting to sustain volume.')
 
     brand_fig(fig, 'Median Home Prices: Existing vs. New',
               subtitle='National | Dollars',
@@ -1155,7 +1193,7 @@ def chart_20():
     ax.invert_yaxis()
     ax.set_xlim(0, total * 1.25)
 
-    add_annotation_box(ax, f'Total: ~${total:,} per unit\n~4-5% of median new home price.', x=0.75, y=0.85)
+    add_annotation_box(ax, f'Total: ~${total:,} per unit\n~4-5% of median new home price.')
 
     brand_fig(fig, 'Estimated Tariff Impact on New Home Construction',
               subtitle='Cost Per Unit by Material Category',
@@ -1269,7 +1307,7 @@ def chart_22():
     h2, l2 = ax2.get_legend_handles_labels()
     ax.legend(h2 + h1, l2 + l1, loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'ZORI leads CPI Shelter by 12-18 months.\nMarket rents peaked 2022, shelter CPI peaked 2024.', x=0.22, y=0.70)
+    add_annotation_box(ax, 'ZORI leads CPI Shelter by 12-18 months.\nMarket rents peaked 2022, shelter CPI peaked 2024.')
 
     brand_fig(fig, 'Zillow ZORI vs CPI Shelter Inflation',
               subtitle='Market Rents Lead Official Shelter CPI by 12-18 Months',
@@ -1304,7 +1342,7 @@ def chart_23():
     add_last_value_label(ax, zhvi_yoy, color=THEME['primary'], fmt='{:.1f}%')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'ZHVI leads Case-Shiller by 1-2 months.\nBroader coverage (all homes vs repeat sales).', x=0.55, y=0.90)
+    add_annotation_box(ax, 'ZHVI leads Case-Shiller by 1-2 months.\nBroader coverage (all homes vs repeat sales).')
 
     brand_fig(fig, 'Zillow ZHVI vs Case-Shiller National',
               subtitle='Home Price Indices Year-over-Year',
@@ -1390,7 +1428,7 @@ def chart_25():
     h2, l2 = ax2.get_legend_handles_labels()
     ax1.legend(h1 + h2, l1 + l2, loc='upper right', **legend_style())
 
-    add_annotation_box(ax1, 'Inventory elevated vs 2020 lows\nbut months supply rising on weak demand.', x=0.45, y=0.93)
+    add_annotation_box(ax1, 'Inventory elevated vs 2020 lows\nbut months supply rising on weak demand.')
 
     brand_fig(fig, 'New Home Inventory and Months\' Supply',
               subtitle='Homes For Sale (Thousands) vs. Months at Current Sales Pace',
@@ -1435,7 +1473,7 @@ def chart_26():
     h2, l2 = ax2.get_legend_handles_labels()
     ax1.legend(h1 + h2, l1 + l2, loc='upper right', **legend_style())
 
-    add_annotation_box(ax1, 'MF completion wave pushing vacancy higher.\nRent growth normalized from 15%+ to <2%.', x=0.60, y=0.92)
+    add_annotation_box(ax1, 'MF completion wave pushing vacancy higher.\nRent growth normalized from 15%+ to <2%.')
 
     brand_fig(fig, 'Zillow ZORI YoY% and Rental Vacancy Rate',
               subtitle='Rent Growth Normalizing as Multifamily Supply Delivers',
@@ -1487,7 +1525,7 @@ def chart_27():
     ax1.legend(loc='upper left', **legend_style())
     ax2.legend(loc='upper right', **legend_style())
 
-    add_annotation_box(ax1, 'Sales collapsed from 6.5M to 3.9M.\nFrozen in 3.8-4.3M band since mid-2023.', x=0.80, y=0.80)
+    add_annotation_box(ax1, 'Sales collapsed from 6.5M to 3.9M.\nFrozen in 3.8-4.3M band since mid-2023.')
 
     brand_fig(fig, 'Existing Home Sales vs. 30-Year Mortgage Rate',
               subtitle='Inverted Rate Axis | The Frozen Market',
@@ -1543,7 +1581,7 @@ def chart_28():
     add_last_value_label(ax, nahb_series, color=pill_color, fmt='{:.0f}')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, '21 months below 50.\nBuilders buying volume with margin.', x=0.18, y=0.88)
+    add_annotation_box(ax, '21 months below 50.\nBuilders buying volume with margin.')
 
     brand_fig(fig, 'NAHB Housing Market Index',
               subtitle='Builder Sentiment | Above 50 = Expansion',
@@ -1584,7 +1622,7 @@ def chart_29():
     add_last_value_label(ax, mba_smooth, color=THEME['primary'], fmt='{:,.0f}')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'Highest-frequency demand signal.\nLeads sales by 4-8 weeks.', x=0.78, y=0.88)
+    add_annotation_box(ax, 'Highest-frequency demand signal.\nLeads sales by 4-8 weeks.')
 
     brand_fig(fig, 'MBA Purchase Application Index',
               subtitle='Mortgage Demand | 3-Month Moving Average',
@@ -1624,7 +1662,7 @@ def chart_30():
     add_last_value_label(ax, phs_series, color=THEME['primary'], fmt='{:.1f}%')
     ax.legend(loc='upper left', **legend_style())
 
-    add_annotation_box(ax, 'Pending sales = signed contracts.\nLeads closings by 1-2 months.', x=0.78, y=0.15)
+    add_annotation_box(ax, 'Pending sales = signed contracts.\nLeads closings by 1-2 months.')
 
     brand_fig(fig, 'Pending Home Sales',
               subtitle='Year-over-Year % Change',

--- a/Scripts/chart_generation/lhm_chart_template.py
+++ b/Scripts/chart_generation/lhm_chart_template.py
@@ -20,6 +20,7 @@ changes, update THIS file and every downstream chart generator inherits it.
 """
 
 import os
+import textwrap
 from datetime import datetime
 
 import matplotlib.image as mpimg
@@ -193,10 +194,44 @@ def style_single_ax(ax, fmt='{:.1f}'):
 # ============================================
 # ANNOTATIONS
 # ============================================
-def add_annotation_box(ax, text, x=0.50, y=0.95, ha='center'):
-    """White callout box with Ocean border and Ocean text.
-    Clean, neutral, reads on any background. Larger font.
-    High zorder so bars/lines never bleed through."""
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y, ha='center'):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
     ax.text(x, y, text, transform=ax.transAxes,
             fontsize=14, fontweight='bold', color=COLORS['ocean'],
             ha=ha, va='top', style='italic', zorder=20,

--- a/Scripts/chart_generation/plumbing_edu_charts.py
+++ b/Scripts/chart_generation/plumbing_edu_charts.py
@@ -15,6 +15,7 @@ Usage:
 """
 
 import os
+import textwrap
 import argparse
 import time
 import ssl
@@ -284,8 +285,45 @@ def style_single_ax(ax, fmt='{:.1f}%'):
     ax.yaxis.set_major_formatter(FuncFormatter(lambda x, p: fmt.format(x)))
 
 
-def add_annotation_box(ax, text, x=0.50, y=0.95):
-    """Add takeaway annotation box."""
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     box_fc = '#2389BB'
     txt_color = '#ffffff'
     ax.text(x, y, text, transform=ax.transAxes,
@@ -451,8 +489,7 @@ def chart_01():
 
     # Annotation for the LCLOR band
     add_annotation_box(ax, 'Sep 2024 Fed minutes: reserves approaching\n'
-                       '"lowest comfortable level" ($3.0\u20133.25T)',
-                       x=0.70, y=0.25)
+                       '"lowest comfortable level" ($3.0\u20133.25T)')
 
     style_single_ax(ax, fmt='${:.1f}T')
     set_xlim_to_data(ax, reserves.index)
@@ -659,8 +696,7 @@ def chart_04b():
     ax.legend(loc='upper left', fontsize=9, **legend_style())
 
     add_annotation_box(ax, 'When secured (SOFR) costs more than unsecured (EFFR),\n'
-                       'dealer balance sheet capacity is the binding constraint.',
-                       x=0.50, y=0.20)
+                       'dealer balance sheet capacity is the binding constraint.')
 
     brand_fig(fig, 'When Secured Costs More Than Unsecured',
               subtitle='SOFR \u2212 EFFR Spread (Dealer Capacity Barometer)',
@@ -816,8 +852,7 @@ def chart_07():
             label=f'MMF Total Assets (${mmf_t.iloc[-1]:.2f}T)')
 
     add_annotation_box(ax, 'RRP drained to zero: $2.5T in cash migrated\n'
-                       'from the Fed into money market funds and T-bills.',
-                       x=0.40, y=0.95)
+                       'from the Fed into money market funds and T-bills.')
 
     style_single_ax(ax, fmt='${:.1f}T')
     set_xlim_to_data(ax, mmf_t.index)
@@ -1031,8 +1066,7 @@ def chart_11():
                     fontsize=9, fontweight='bold', color=THEME['muted'], va='top')
 
     add_annotation_box(ax, 'Repo market has more than tripled since 2018.\n'
-                       'More volume = more intermediation demand on constrained dealer balance sheets.',
-                       x=0.35, y=0.50)
+                       'More volume = more intermediation demand on constrained dealer balance sheets.')
 
     style_single_ax(ax, fmt='${:.1f}T')
     set_xlim_to_data(ax, vol_t.index)

--- a/Scripts/chart_generation/positioning_update_2_charts.py
+++ b/Scripts/chart_generation/positioning_update_2_charts.py
@@ -14,6 +14,7 @@ import matplotlib.image as mpimg
 from matplotlib.ticker import FuncFormatter
 from datetime import datetime, timedelta
 import os
+import textwrap
 
 # =============================================================================
 # THEME & PALETTE
@@ -183,7 +184,45 @@ def add_last_value_label(ax, y_data, color, fmt='{:.1f}%', side='right', fontsiz
                     xytext=(-6, 0), textcoords='offset points', bbox=pill, clip_on=False)
 
 
-def add_annotation_box(ax, text, x=0.52, y=0.92):
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     ax.text(x, y, text, transform=ax.transAxes,
             fontsize=12, color='#2389BB', ha='center', va='top',
             fontweight='bold', style='italic',
@@ -336,8 +375,7 @@ def fig01_defensive_basket():
     ax.tick_params(axis='y', labelsize=13, pad=8)
     ax.tick_params(axis='x', labelsize=10)
 
-    add_annotation_box(ax, 'Defensive basket: up to +8% relative in five weeks.\nIn a flat tape, that is the entire game.',
-                       x=0.75, y=0.52)
+    add_annotation_box(ax, 'Defensive basket: up to +8% relative in five weeks.\nIn a flat tape, that is the entire game.')
 
     brand_fig(fig, 'Defensive Basket vs SPY: Jan 15 to Feb 22',
               'Relative performance, 5-week holding period',
@@ -372,8 +410,7 @@ def fig02_quits_rate():
     add_last_value_label(ax, q_plot, THEME['primary'], fmt='{:.1f}%')
 
     last_val = q_plot.iloc[-1]
-    add_annotation_box(ax, f'Quits at {last_val:.1f}%: sitting on the exact threshold\nthat preceded the last three recessions.',
-                       x=0.40, y=0.92)
+    add_annotation_box(ax, f'Quits at {last_val:.1f}%: sitting on the exact threshold\nthat preceded the last three recessions.')
 
     ax.legend(loc='upper left', **legend_style())
     brand_fig(fig, 'JOLTS Quits Rate: Sitting on the Line',
@@ -404,8 +441,7 @@ def fig03_openings_rate():
     add_last_value_label(ax, o_plot, THEME['primary'], fmt='{:.1f}%')
 
     last_val = o_plot.iloc[-1]
-    add_annotation_box(ax, f'Openings rate at {last_val:.1f}%: lowest since 2020.\nProfessional services, retail, and finance leading the decline.',
-                       x=0.50, y=0.92)
+    add_annotation_box(ax, f'Openings rate at {last_val:.1f}%: lowest since 2020.\nProfessional services, retail, and finance leading the decline.')
 
     ax.legend(loc='upper left', **legend_style())
     brand_fig(fig, 'JOLTS Job Openings Rate: Collapse to 2020 Lows',
@@ -443,8 +479,7 @@ def fig04_lfi():
     add_last_value_label(ax, lfi_plot, THEME['primary'], fmt='{:.2f}')
 
     last_val = lfi_plot.iloc[-1]
-    add_annotation_box(ax, f'LFI at {last_val:+.2f}: well above the +0.50 fragility threshold.\nLong-term unemployment building, quits decelerating.',
-                       x=0.50, y=0.15)
+    add_annotation_box(ax, f'LFI at {last_val:+.2f}: well above the +0.50 fragility threshold.\nLong-term unemployment building, quits decelerating.')
 
     ax.legend(loc='upper left', **legend_style())
     brand_fig(fig, 'Labor Fragility Index (LFI): Structural Weakness Building',
@@ -480,8 +515,7 @@ def fig05_hy_oas():
     add_last_value_label(ax, hy_plot, THEME['primary'], fmt='{:.0f}')
 
     last_val = hy_plot.iloc[-1]
-    add_annotation_box(ax, f'HY OAS at {last_val:.0f} bps: below the 300 bps complacent\nthreshold. Credit pricing a different economy than labor.',
-                       x=0.70, y=0.92)
+    add_annotation_box(ax, f'HY OAS at {last_val:.0f} bps: below the 300 bps complacent\nthreshold. Credit pricing a different economy than labor.')
 
     ax.legend(loc='upper left', **legend_style())
     brand_fig(fig, 'HY OAS: Credit Still in Denial',
@@ -543,8 +577,7 @@ def fig05_credit_labor_divergence():
     add_last_value_label(ax2, q_plot, c_primary, fmt='{:.1f}%', side='right')
     add_last_value_label(ax1, hy_bps, c_secondary, fmt='{:.0f}', side='left')
 
-    add_annotation_box(ax1, 'Credit and labor are pricing two different economies.\nThe divergence has persisted for over two years.',
-                       x=0.50, y=0.97)
+    add_annotation_box(ax1, 'Credit and labor are pricing two different economies.\nThe divergence has persisted for over two years.')
 
     # Combined legend
     lines1, labels1 = ax1.get_legend_handles_labels()
@@ -588,8 +621,7 @@ def fig06_clg():
     add_last_value_label(ax, clg_plot, THEME['primary'], fmt='{:.2f}')
 
     last_val = clg_plot.iloc[-1]
-    add_annotation_box(ax, f'CLG at {last_val:.2f}: deeply below -1.0 threshold.\nSpreads too tight for the labor reality underneath.',
-                       x=0.50, y=0.92)
+    add_annotation_box(ax, f'CLG at {last_val:.2f}: deeply below -1.0 threshold.\nSpreads too tight for the labor reality underneath.')
 
     ax.legend(loc='upper left', **legend_style())
     brand_fig(fig, 'Credit-Labor Gap (CLG): Deeply Negative',
@@ -634,8 +666,7 @@ def fig07_vix():
     add_last_value_label(ax, vix_50d.dropna(), THEME['secondary'], fmt='{:.1f}', side='right')
 
     last_val = v_plot.iloc[-1]
-    add_annotation_box(ax, f'VIX at {last_val:.1f}: no longer complacent, not yet panicking.\nSCOTUS relief compressed the tariff tail.',
-                       x=0.55, y=0.92)
+    add_annotation_box(ax, f'VIX at {last_val:.1f}: no longer complacent, not yet panicking.\nSCOTUS relief compressed the tariff tail.')
 
     ax.legend(loc='upper left', **legend_style())
     brand_fig(fig, 'VIX: From Complacency to Recalibration',
@@ -676,8 +707,7 @@ def fig08_sofr_effr():
     add_last_value_label(ax, e_plot, THEME['secondary'], fmt='{:.2f}%', side='left')
 
     last_spread = (s_plot.iloc[-1] - e_plot.iloc[-1]) * 100
-    add_annotation_box(ax, f'SOFR-EFFR spread: ~{last_spread:.0f} bps. Defensive, not Disorderly.\nThe One Switch: 15-20 bps = regime change.',
-                       x=0.50, y=0.20)
+    add_annotation_box(ax, f'SOFR-EFFR spread: ~{last_spread:.0f} bps. Defensive, not Disorderly.\nThe One Switch: 15-20 bps = regime change.')
 
     ax.legend(loc='upper left', **legend_style())
     brand_fig(fig, 'SOFR vs EFFR: The One Switch',
@@ -727,8 +757,7 @@ def fig09_lci():
     add_last_value_label(ax, lci_plot, THEME['primary'], fmt='{:.2f}')
 
     last_val = lci_plot.iloc[-1]
-    add_annotation_box(ax, f'LCI at {last_val:.2f}: approaching but not yet breaching -0.50.\nRRP exhausted. System operating without a shock absorber.',
-                       x=0.45, y=0.92)
+    add_annotation_box(ax, f'LCI at {last_val:.2f}: approaching but not yet breaching -0.50.\nRRP exhausted. System operating without a shock absorber.')
 
     ax.legend(loc='upper left', **legend_style())
     brand_fig(fig, 'Liquidity Cushion Index (LCI): Approaching Scarce',
@@ -776,8 +805,7 @@ def fig10_yield_curve():
     add_last_value_label(ax1, t_plot, c_secondary, fmt='{:.2f}%', side='left')
 
     last_curve = c_plot.iloc[-1]
-    add_annotation_box(ax1, f'10Y-2Y at +{last_curve*100:.0f} bps. Steepener building:\ndeficit dynamics, tariff pass-through, anchored front end.',
-                       x=0.50, y=0.97)
+    add_annotation_box(ax1, f'10Y-2Y at +{last_curve*100:.0f} bps. Steepener building:\ndeficit dynamics, tariff pass-through, anchored front end.')
 
     # Combined legend
     lines1, labels1 = ax1.get_legend_handles_labels()
@@ -830,8 +858,7 @@ def fig11_mri():
     else:
         regime = 'Low Risk'
 
-    add_annotation_box(ax, f'MRI at {last_val:.2f}: {regime} regime.\nLabor and credit divergence persists. Defensive posture holds.',
-                       x=0.50, y=0.15)
+    add_annotation_box(ax, f'MRI at {last_val:.2f}: {regime} regime.\nLabor and credit divergence persists. Defensive posture holds.')
 
     ax.legend(loc='upper left', **legend_style())
     brand_fig(fig, 'Macro Risk Index (MRI): Regime Classification',

--- a/Scripts/chart_generation/prices_edu_charts.py
+++ b/Scripts/chart_generation/prices_edu_charts.py
@@ -12,6 +12,7 @@ Usage:
 """
 
 import os
+import textwrap
 import argparse
 from datetime import datetime
 import pandas as pd
@@ -203,8 +204,45 @@ def style_single_ax(ax):
     ax.yaxis.set_major_formatter(FuncFormatter(lambda x, p: f'{x:.1f}%'))
 
 
-def add_annotation_box(ax, text, x=0.52, y=0.92):
-    """Add takeaway annotation box in dead space."""
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     ax.text(x, y, text, transform=ax.transAxes,
             fontsize=10, color=THEME['fg'], ha='center', va='top',
             style='italic',
@@ -511,8 +549,7 @@ def chart_02():
     pce_last = pce.iloc[-1]
     pce_above = ((pce_last / 2.0) - 1) * 100
     add_annotation_box(ax1,
-        f"The Fed targets Core PCE, not headline CPI.\nAt {pce_last:.1f}%, we're {pce_above:.0f}% above the 2% goal.",
-        x=0.50, y=0.92)
+        f"The Fed targets Core PCE, not headline CPI.\nAt {pce_last:.1f}%, we're {pce_above:.0f}% above the 2% goal.")
 
     brand_fig(fig, 'Headline CPI vs Core PCE: The Gap That Matters',
               subtitle='The number the Fed actually watches',
@@ -557,8 +594,7 @@ def chart_03():
     ax.legend(loc='upper left', **legend_style())
 
     add_annotation_box(ax,
-        f"Shelter = 34% of CPI weight.\nThe lag is mechanical, the decline is baked in.",
-        x=0.50, y=0.92)
+        f"Shelter = 34% of CPI weight.\nThe lag is mechanical, the decline is baked in.")
 
     brand_fig(fig, 'The Shelter Lag Trap',
               subtitle='Market rents lead CPI shelter by 12-18 months',
@@ -619,8 +655,7 @@ def chart_04():
     ax1.legend(lines1 + lines2, labels1 + labels2, loc='upper left', **legend_style())
 
     add_annotation_box(ax1,
-        f"Flexible inflation normalized.\nSticky at {sticky.iloc[-1]:.1f}% is {sticky.iloc[-1]/2:.1f}x the target.",
-        x=0.50, y=0.92)
+        f"Flexible inflation normalized.\nSticky at {sticky.iloc[-1]:.1f}% is {sticky.iloc[-1]/2:.1f}x the target.")
 
     brand_fig(fig, 'Sticky vs Flexible: The Persistence Problem',
               subtitle='Flexible leads Sticky by ~12 months',
@@ -675,8 +710,7 @@ def chart_05():
     ppi_last, cpi_last = ppi.iloc[-1], cpi.iloc[-1]
     ppi_vs = "below" if ppi_last < cpi_last else "above"
     add_annotation_box(ax1,
-        f"PPI ({ppi_last:.1f}%) {ppi_vs} CPI ({cpi_last:.1f}%) = {'dis' if ppi_last < cpi_last else ''}inflationary\npressure in the pipeline. Pass-through takes 3-6 months.",
-        x=0.50, y=0.92)
+        f"PPI ({ppi_last:.1f}%) {ppi_vs} CPI ({cpi_last:.1f}%) = {'dis' if ppi_last < cpi_last else ''}inflationary\npressure in the pipeline. Pass-through takes 3-6 months.")
 
     brand_fig(fig, 'The Pipeline: PPI Leads CPI',
               subtitle='Producer prices signal what consumer prices do next',
@@ -730,8 +764,7 @@ def chart_06():
     ax1.legend(lines1 + lines2, labels1 + labels2, loc='upper left', **legend_style())
 
     add_annotation_box(ax1,
-        f"5Y5Y at {fwd.iloc[-1]:.2f}%: {'drifting, not de-anchored' if fwd.iloc[-1] < 3.0 else 'de-anchoring risk'}.\nIf this breaks 3%, all bets are off.",
-        x=0.50, y=0.12)
+        f"5Y5Y at {fwd.iloc[-1]:.2f}%: {'drifting, not de-anchored' if fwd.iloc[-1] < 3.0 else 'de-anchoring risk'}.\nIf this breaks 3%, all bets are off.")
 
     brand_fig(fig, 'Inflation Expectations: Are They Anchored?',
               subtitle='The line between controlled and uncontrolled inflation',
@@ -784,8 +817,7 @@ def chart_07():
     ax1.legend(lines1 + lines2, labels1 + labels2, loc='upper left', **legend_style())
 
     add_annotation_box(ax1,
-        f"Trimmed mean strips the noise.\nAt {trimmed.iloc[-1]:.1f}%, the stickiness is broad-based.",
-        x=0.45, y=0.92)
+        f"Trimmed mean strips the noise.\nAt {trimmed.iloc[-1]:.1f}%, the stickiness is broad-based.")
 
     brand_fig(fig, 'Trimmed Mean vs Core: The Signal Beneath the Noise',
               subtitle='Dallas Fed trimmed mean confirms persistent inflation',
@@ -840,8 +872,7 @@ def chart_08():
     eci_last, pce_last = eci.iloc[-1], core_pce.iloc[-1]
     spiral_status = "No wage-price spiral." if eci_last > pce_last else "Wages falling behind prices."
     add_annotation_box(ax1,
-        f"{spiral_status} ECI at {eci_last:.1f}% vs Core PCE\nat {pce_last:.1f}%. Equilibrium, not resolution.",
-        x=0.50, y=0.92)
+        f"{spiral_status} ECI at {eci_last:.1f}% vs Core PCE\nat {pce_last:.1f}%. Equilibrium, not resolution.")
 
     brand_fig(fig, 'Wages vs Prices: The Spiral Check',
               subtitle='ECI compensation growth vs core inflation',
@@ -913,8 +944,7 @@ def _chart_09_core(shifted=False):
     dollar_dir = "Strong" if dollar_yoy.iloc[-1] > 0 else "Weak"
     goods_dir = "deflation" if goods.iloc[-1] < 0 else "inflation"
     add_annotation_box(ax1,
-        f"{dollar_dir} dollar ({dollar_yoy.iloc[-1]:.1f}% YoY) \u2192 goods {goods_dir}.\nThe 9-18 month lag is mechanical.",
-        x=0.50, y=0.92)
+        f"{dollar_dir} dollar ({dollar_yoy.iloc[-1]:.1f}% YoY) \u2192 goods {goods_dir}.\nThe 9-18 month lag is mechanical.")
 
     goods_title_word = "Deflation" if goods.iloc[-1] < 0 else "Disinflation"
     brand_fig(fig, f'The Dollar Channel: Goods {goods_title_word} Explained',
@@ -1048,8 +1078,7 @@ def chart_10():
     else:
         regime_note = "Easing urgently needed."
     add_annotation_box(ax,
-        f"PCI at {pci_last:.2f}: {regime} regime.\n{regime_note}",
-        x=0.35, y=0.92)
+        f"PCI at {pci_last:.2f}: {regime} regime.\n{regime_note}")
 
     brand_fig(fig, 'Prices Composite Index (PCI)',
               subtitle='Synthesizing all inflation signals into one regime indicator',

--- a/Scripts/chart_generation/structure_edu_charts.py
+++ b/Scripts/chart_generation/structure_edu_charts.py
@@ -15,6 +15,7 @@ Usage:
 """
 
 import os
+import textwrap
 import argparse
 import time
 import ssl
@@ -281,8 +282,45 @@ def style_single_ax(ax, fmt='{:.1f}'):
     ax.yaxis.set_major_formatter(FuncFormatter(lambda x, p: fmt.format(x)))
 
 
-def add_annotation_box(ax, text, x=0.50, y=0.95):
-    """Add takeaway annotation box."""
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     box_fc = '#2389BB'
     txt_color = '#ffffff'
     ax.text(x, y, text, transform=ax.transAxes,

--- a/Scripts/chart_generation/trade_edu_charts.py
+++ b/Scripts/chart_generation/trade_edu_charts.py
@@ -16,6 +16,7 @@ Usage:
 """
 
 import os
+import textwrap
 import argparse
 import time
 import ssl
@@ -281,8 +282,45 @@ def style_single_ax(ax, fmt='{:.1f}%'):
     ax.yaxis.set_major_formatter(FuncFormatter(lambda x, p: fmt.format(x)))
 
 
-def add_annotation_box(ax, text, x=0.52, y=0.92):
-    """Add takeaway annotation box in dead space."""
+
+# --- Annotation placement rule (v4.1, May 2026 — Bob's universal rule) ---
+# All annotation boxes anchor at (0.5, 0.98) in axes coords with va='top'.
+# Text wraps at ANNOTATION_WRAP_WIDTH chars/line. Do NOT override x/y per
+# chart: if an annotation overlaps data, delete it rather than reposition.
+ANNOTATION_X = 0.5
+ANNOTATION_Y = 0.98
+ANNOTATION_WRAP_WIDTH = 20
+
+
+def _wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of annotation text at `width` characters.
+    Preserves explicit newlines; never splits words or hyphenated tokens."""
+    if not text:
+        return text
+    out = []
+    for line in str(text).split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
+
+
+def add_annotation_box(ax, text, x=ANNOTATION_X, y=ANNOTATION_Y):
+    """Top-center takeaway callout, auto-wrapped at 20 chars.
+
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026): anchor is
+    (0.5, 0.98) with va='top'. Do not override x/y per chart.
+    If the box overlaps data, delete the annotation instead of
+    repositioning it. Use sparingly — a strong chart + caption
+    is almost always better than an in-chart annotation.
+    """
+    text = _wrap_annotation_text(text)
+    text = _wrap_annotation_text(text)
     box_fc = '#2389BB'
     box_alpha = 1.0
     txt_color = '#ffffff'
@@ -459,8 +497,7 @@ def chart_01():
     add_annotation_box(ax,
         f"Trade deficit at ${bal.iloc[-1]:.0f}B.\n"
         f"Narrowing from peak, but driven by\n"
-        f"demand destruction, not competitiveness.",
-        x=0.675, y=0.15)
+        f"demand destruction, not competitiveness.")
 
     brand_fig(fig, 'U.S. Trade Balance: Goods & Services',
               subtitle='The persistent deficit tells half the story',
@@ -514,8 +551,7 @@ def chart_02():
 
     add_annotation_box(ax1,
         "Import prices lead CPI goods by 3-6 months.\n"
-        "Tariff pass-through is the pipeline right now.",
-        x=0.545, y=0.92)
+        "Tariff pass-through is the pipeline right now.")
 
     brand_fig(fig, 'The Inflation Pipeline: Import Prices → CPI Goods',
               subtitle='What you pay at the border shows up at the register',
@@ -556,8 +592,7 @@ def chart_03():
 
     add_annotation_box(ax,
         "Strong dollar = cheap imports, expensive exports.\n"
-        "EM currencies under disproportionate stress.",
-        x=0.50, y=0.95)
+        "EM currencies under disproportionate stress.")
 
     brand_fig(fig, 'Trade-Weighted Dollar: The Competitiveness Gauge',
               subtitle='Broad, Advanced Economies, and Emerging Markets',
@@ -612,8 +647,7 @@ def chart_04():
 
     add_annotation_box(ax,
         "Exports rebounding while imports contract.\n"
-        "Divergence signals shifting demand dynamics.",
-        x=0.52, y=0.92)
+        "Divergence signals shifting demand dynamics.")
 
     brand_fig(fig, 'U.S. Exports & Imports: Year-Over-Year Growth',
               subtitle='When both decelerate, global demand is weakening',
@@ -658,8 +692,7 @@ def chart_05():
 
     add_annotation_box(ax,
         "China imports peaked 2018 and are falling.\n"
-        "Decoupling is real: 22% → under 10% import share.",
-        x=0.40, y=0.92)
+        "Decoupling is real: 22% → under 10% import share.")
 
     brand_fig(fig, 'U.S.-China Trade: The Decoupling',
               subtitle='Import share falling, but the deficit shifted, not eliminated',
@@ -706,8 +739,7 @@ def chart_06():
 
     add_annotation_box(ax,
         "Ex-petroleum strips oil noise.\n"
-        "Consumer goods prices tell you what hits wallets.",
-        x=0.57, y=0.92)
+        "Consumer goods prices tell you what hits wallets.")
 
     brand_fig(fig, 'Import Price Decomposition',
               subtitle='Where the tariff pressure is actually landing',
@@ -757,8 +789,7 @@ def chart_07():
 
     add_annotation_box(ax,
         "Above 100 = export prices outpacing imports.\n"
-        "Energy independence and services exports driving favorable terms.",
-        x=0.52, y=0.92)
+        "Energy independence and services exports driving favorable terms.")
 
     brand_fig(fig, 'Terms of Trade: Competitiveness Barometer',
               subtitle='Export prices relative to import prices (100 = neutral)',
@@ -813,8 +844,7 @@ def chart_08():
 
     add_annotation_box(ax,
         "Trade policy uncertainty leads capex by 3-6 months.\n"
-        "At record highs, eclipsing 2019 trade war peaks.",
-        x=0.55, y=0.80)
+        "At record highs, eclipsing 2019 trade war peaks.")
 
     brand_fig(fig, 'Trade Policy Uncertainty Index',
               subtitle='When businesses cannot plan, they do not invest',
@@ -865,8 +895,7 @@ def chart_09():
 
     add_annotation_box(ax,
         "Goods deficit dominates, but services surplus\n"
-        "and primary income partially offset.",
-        x=0.55, y=0.15)
+        "and primary income partially offset.")
 
     brand_fig(fig, 'Current Account Decomposition',
               subtitle='The financial mirror of every trade deficit',
@@ -915,8 +944,7 @@ def chart_10():
 
     add_annotation_box(ax,
         "Wholesale I/S rising = importers front-loading\n"
-        "ahead of tariff escalation. Watch for reversal.",
-        x=0.52, y=0.93)
+        "ahead of tariff escalation. Watch for reversal.")
 
     brand_fig(fig, 'Inventory-to-Sales Ratios',
               subtitle='Where trade flows meet domestic demand',
@@ -964,8 +992,7 @@ def chart_11():
 
     add_annotation_box(ax,
         "Services surplus (~$22B/mo) partially offsets\n"
-        "the goods deficit (~$100B/mo). Tech, finance, IP.",
-        x=0.70, y=0.92)
+        "the goods deficit (~$100B/mo). Tech, finance, IP.")
 
     brand_fig(fig, 'Goods vs Services Trade Balance',
               subtitle='The structural split that defines U.S. trade',
@@ -1032,8 +1059,7 @@ def chart_12():
 
     add_annotation_box(ax,
         "Dollar Z-RoC: momentum of the dollar.\n"
-        "At extremes (>1.5 or <-1.5), reversals are probable.",
-        x=0.52, y=0.955)
+        "At extremes (>1.5 or <-1.5), reversals are probable.")
 
     brand_fig(fig, 'Dollar Z-RoC: The Momentum Signal',
               subtitle='63-day rate of change, z-scored for regime detection',
@@ -1088,8 +1114,7 @@ def chart_13():
 
     add_annotation_box(ax1,
         "Import prices ex-petro lead core PCE by ~4 months.\n"
-        "The tariff pipeline is building pressure.",
-        x=0.55, y=0.93)
+        "The tariff pipeline is building pressure.")
 
     brand_fig(fig, 'The Tariff Pipeline: Import Prices → Core PCE',
               subtitle='Import prices ex-petroleum (4-month lag) vs Core PCE',
@@ -1141,8 +1166,7 @@ def chart_14():
 
     add_annotation_box(ax1,
         "Strong dollar = weak exports. The relationship\n"
-        "is tight with a 3-6 month transmission lag.",
-        x=0.52, y=0.15)
+        "is tight with a 3-6 month transmission lag.")
 
     brand_fig(fig, 'The Dollar-Export Trade-Off',
               subtitle='Dollar strength (inverted) vs real export growth',
@@ -1186,8 +1210,7 @@ def chart_15():
 
     add_annotation_box(ax,
         "Japan deficit narrowing as yen weakens.\n"
-        "Autos and semiconductors dominate imports.",
-        x=0.30, y=0.92)
+        "Autos and semiconductors dominate imports.")
 
     brand_fig(fig, 'U.S.-Japan Trade',
               subtitle='Key bilateral for autos, semiconductors, and the yen carry trade',
@@ -1236,8 +1259,7 @@ def chart_16():
     add_annotation_box(ax,
         f"BIS REER {dev_pct:+.0f}% vs 10Y average.\n"
         "Inflation-adjusted: the gold standard for\n"
-        "competitiveness analysis.",
-        x=0.30, y=0.92)
+        "competitiveness analysis.")
 
     brand_fig(fig, 'BIS Real Effective Exchange Rate',
               subtitle='Dollar valuation adjusted for inflation differentials',
@@ -1300,8 +1322,7 @@ def chart_17():
 
     add_annotation_box(ax,
         "Negative = import costs rising faster than\n"
-        "export prices. Margin compression for U.S. firms.",
-        x=0.52, y=0.15)
+        "export prices. Margin compression for U.S. firms.")
 
     brand_fig(fig, 'Export-Import Price Spread',
               subtitle='The margin signal: who is absorbing the cost pressure?',
@@ -1344,8 +1365,7 @@ def chart_18():
 
     add_annotation_box(ax,
         "Freight volumes are the physical heartbeat of trade.\n"
-        "When all four decline, goods recession is underway.",
-        x=0.52, y=0.15)
+        "When all four decline, goods recession is underway.")
 
     brand_fig(fig, 'Domestic Freight: The Physical Trade Signal',
               subtitle='Year-over-year growth across transport modes',
@@ -1394,8 +1414,7 @@ def chart_19():
     spread = nominal.iloc[-1] - real.iloc[-1]
     add_annotation_box(ax,
         f"Gap of {spread:.1f} ppts = inflation eating\n"
-        "into real purchasing power. Tariffs widen this.",
-        x=0.52, y=0.15)
+        "into real purchasing power. Tariffs widen this.")
 
     brand_fig(fig, 'Real vs Nominal Retail Sales',
               subtitle='The inflation tax on consumer spending',
@@ -1444,8 +1463,7 @@ def chart_20():
 
     add_annotation_box(ax,
         "When EM line > DM line, emerging markets are\n"
-        "under disproportionate dollar pressure.",
-        x=0.52, y=0.15)
+        "under disproportionate dollar pressure.")
 
     brand_fig(fig, 'Dollar Strength: DM vs EM',
               subtitle='Who is bearing the brunt of dollar strength?',
@@ -1485,8 +1503,7 @@ def chart_21():
 
     add_annotation_box(ax,
         "Net exports are a persistent GDP drag.\n"
-        "Narrowing = GDP add, but quality matters.",
-        x=0.685, y=0.20)
+        "Narrowing = GDP add, but quality matters.")
 
     brand_fig(fig, 'Real Net Exports: The GDP Drag',
               subtitle='Trade as a GDP component (chained 2017 dollars)',
@@ -1546,8 +1563,7 @@ def chart_22():
 
     add_annotation_box(ax,
         "50+ years of structural deficit.\n"
-        "Each trade regime shift is visible.",
-        x=0.70, y=0.50)
+        "Each trade regime shift is visible.")
 
     brand_fig(fig, 'U.S. Trade Balance: The Long View',
               subtitle='From surplus to structural deficit since 1971',
@@ -1592,8 +1608,7 @@ def chart_23():
 
     add_annotation_box(ax1,
         "Structural shift: from net importer to\n"
-        "near-net exporter. Deficit is now goods, not oil.",
-        x=0.52, y=0.15)
+        "near-net exporter. Deficit is now goods, not oil.")
 
     brand_fig(fig, 'U.S. Energy Trade: Production & Exports',
               subtitle='The structural shift from importer to exporter',
@@ -1634,8 +1649,7 @@ def chart_24():
 
     add_annotation_box(ax,
         "Negative TIC = foreigners SELLING U.S. assets.\n"
-        "Watch Japan and China: both slowly reducing.",
-        x=0.52, y=0.92)
+        "Watch Japan and China: both slowly reducing.")
 
     brand_fig(fig, 'TIC Net Long-Term Flows',
               subtitle='The financial mirror: are foreigners still buying?',
@@ -1675,8 +1689,7 @@ def chart_25():
 
     add_annotation_box(ax,
         "These categories are tariff canaries.\n"
-        "Rising prices + falling volumes = pass-through.",
-        x=0.52, y=0.92)
+        "Rising prices + falling volumes = pass-through.")
 
     brand_fig(fig, 'Import-Sensitive Retail Categories',
               subtitle='Where tariff pass-through shows up first',
@@ -1712,8 +1725,7 @@ def chart_26():
 
     add_annotation_box(ax,
         "E-commerce bypasses some tariff pass-through\n"
-        "via competitive pressure. Structural channel shift.",
-        x=0.52, y=0.50)
+        "via competitive pressure. Structural channel shift.")
 
     brand_fig(fig, 'E-Commerce Share of Retail Sales',
               subtitle='The structural shift in how imports reach consumers',
@@ -1751,8 +1763,7 @@ def chart_27():
     add_annotation_box(ax,
         "Foreign Treasury holdings = trade deficit\n"
         "recycled into U.S. debt markets. When this\n"
-        "slows, term premium must rise.",
-        x=0.52, y=0.50)
+        "slows, term premium must rise.")
 
     brand_fig(fig, 'Foreign Holdings of U.S. Treasuries',
               subtitle='The capital account mirror of every trade deficit',
@@ -1810,8 +1821,7 @@ def chart_28():
 
     add_annotation_box(ax1,
         "When All imports spike but ex-petro is flat = oil.\n"
-        "When ex-petro spikes independently = tariffs.",
-        x=0.52, y=0.15)
+        "When ex-petro spikes independently = tariffs.")
 
     brand_fig(fig, 'Separating Oil from Tariffs',
               subtitle='WTI crude vs import prices (all and ex-petroleum)',
@@ -1856,8 +1866,7 @@ def chart_29():
 
     add_annotation_box(ax1,
         "Both rising = dollar strength vs trade partners.\n"
-        "CNY managed float; MXN = nearshoring signal.",
-        x=0.52, y=0.50)
+        "CNY managed float; MXN = nearshoring signal.")
 
     brand_fig(fig, 'Key Bilateral Rates: CNY & MXN',
               subtitle='The currencies that matter most for U.S. trade',
@@ -1909,8 +1918,7 @@ def chart_30():
 
     add_annotation_box(ax1,
         "Dollar weakness = import prices rise.\n"
-        "When both diverge: tariffs or supply shocks.",
-        x=0.52, y=0.15)
+        "When both diverge: tariffs or supply shocks.")
 
     brand_fig(fig, 'Dollar → Import Prices: The Transmission',
               subtitle='Dollar strength (inverted) vs import price inflation',

--- a/Scripts/chart_generation/two_economies_beacon_rebuild.py
+++ b/Scripts/chart_generation/two_economies_beacon_rebuild.py
@@ -103,8 +103,7 @@ def chart1_savings_vs_credit():
     add_annotation_box(
         ax1,
         f"Saving rate {psavert.iloc[-1]:.1f}% (vs 8.5% historical avg).\n"
-        f"Consumer credit growing {totalsl_yoy.iloc[-1]:+.1f}% YoY — filling the gap.",
-        x=0.98, y=0.95, ha='right',
+        f"Consumer credit growing {totalsl_yoy.iloc[-1]:+.1f}% YoY — filling the gap.", ha='right',
     )
 
     brand_fig(
@@ -189,7 +188,6 @@ def chart2_deliq_by_type():
         ax,
         f"Consumer delinquencies at {current[1]:.2f}% — stress building across categories.\n"
         "Business delinquencies remain subdued. Two-speed credit.",
-        x=0.50, y=0.95,
     )
 
     # legend
@@ -270,7 +268,6 @@ def chart3_subprime_auto_2008_vs_current():
         ax,
         "All three subprime auto metrics at or above 2008 peak levels.\n"
         "The headline says 'consumer is fine.' The collateral says otherwise.",
-        x=0.50, y=0.95,
     )
 
     brand_fig(
@@ -325,7 +322,6 @@ def chart4_inflation_by_cohort():
         ax,
         "Bottom 20% experiences 6.1% inflation vs 3.2% for top 20%.\n"
         "Same country. Different price levels.",
-        x=0.28, y=0.95,
     )
 
     brand_fig(
@@ -390,7 +386,6 @@ def chart5_excess_savings_by_quintile():
     add_annotation_box(
         ax,
         "Bottom 80% depleted pandemic windfalls.\nOnly the top 20% remain buffered.",
-        x=0.50, y=0.95,
     )
 
     brand_fig(
@@ -462,7 +457,6 @@ def chart6_unemployment_demographic():
         ax1,
         "55+ workers: lowest unemployment rate but highest long-term share (31%).\n"
         "When they lose a job, they struggle to find another.",
-        x=0.72, y=0.95,
     )
 
     brand_fig(
@@ -543,7 +537,6 @@ def chart7_housing_by_tier():
         ax1,
         "Luxury stable (+2.4%). Entry-level collapsing (-8.6%) with 95 DOM.\n"
         "Housing market is two markets, selling to two consumers.",
-        x=0.50, y=0.95,
     )
 
     brand_fig(
@@ -655,7 +648,6 @@ def chart8_luxury_vs_value_retail():
         ax,
         f'Luxury {lux_chg:+.0f}% since Jan 2022. Value {val_chg:+.0f}% since Jan 2022.\n'
         'Luxury spending grows; lower-income households substitute to value.',
-        x=0.50, y=0.95,
     )
 
     brand_fig(

--- a/Scripts/chart_generation/two_economies_charts.py
+++ b/Scripts/chart_generation/two_economies_charts.py
@@ -64,9 +64,7 @@ def fig1_wealth_concentration():
 
     add_annotation_box(
         ax,
-        'The top 1% hold more wealth than the entire\nbottom 50%. By a factor of 12.',
-        x=0.75, y=0.25
-    )
+        'The top 1% hold more wealth than the entire\nbottom 50%. By a factor of 12.')
 
     brand_fig(fig,
               title='Who Owns America',
@@ -148,9 +146,7 @@ def fig3_savings_rate_quintile():
 
     add_annotation_box(
         ax,
-        "Bottom 60% aren't building a buffer. They're surviving month to month.",
-        x=0.50, y=0.95
-    )
+        "Bottom 60% aren't building a buffer. They're surviving month to month.")
 
     brand_fig(fig,
               title='Personal Savings Rate by Income Group',
@@ -291,9 +287,7 @@ def fig6_delinquency_by_loan_type():
 
     add_annotation_box(
         ax,
-        f'Student loans leading (+{bps_above[0]} bps). Mortgages last. Stress builds from the bottom of the balance sheet up.',
-        x=0.50, y=0.95
-    )
+        f'Student loans leading (+{bps_above[0]} bps). Mortgages last. Stress builds from the bottom of the balance sheet up.')
 
     brand_fig(fig,
               title='Delinquency Stress: Every Category Above Pre-COVID Baseline',
@@ -354,9 +348,7 @@ def fig7_employment_by_firm_size():
     latest_date = adp_m['date'].max().strftime('%B %Y')
     add_annotation_box(
         ax,
-        f'Small firms are the only segment hiring. Large firms are cutting.\nComposition: stable headline, deteriorating job quality.',
-        x=0.50, y=0.95
-    )
+        f'Small firms are the only segment hiring. Large firms are cutting.\nComposition: stable headline, deteriorating job quality.')
 
     brand_fig(fig,
               title="Who's Hiring and Who's Cutting: Employment by Firm Size",
@@ -471,9 +463,7 @@ def fig9_retail_bifurcation():
     val_chg = value_idx.iloc[-1] - 100
     add_annotation_box(
         ax,
-        f'Luxury {lux_chg:+.0f}%. Value/discount {val_chg:+.0f}%. Same economy. Different planets.',
-        x=0.50, y=0.95
-    )
+        f'Luxury {lux_chg:+.0f}%. Value/discount {val_chg:+.0f}%. Same economy. Different planets.')
 
     brand_fig(fig,
               title='Two Consumers, Two Trajectories',
@@ -618,9 +608,7 @@ def fig11_wealth_transfer():
 
     add_annotation_box(
         ax,
-        '~$2T transfers every year. Most goes to the wealthy.\n55% of Millennials expect some. That changes the spending math.',
-        x=0.55, y=0.95
-    )
+        '~$2T transfers every year. Most goes to the wealthy.\n55% of Millennials expect some. That changes the spending math.')
 
     brand_fig(fig,
               title='The Great Wealth Transfer: $2 Trillion a Year and Accelerating',
@@ -659,9 +647,7 @@ def fig12_downpayment_sources():
 
     add_annotation_box(
         ax,
-        '40% of first-time buyers used a gift or inheritance.\nHousing is inheritance-sensitive, not just rate-sensitive. h/t @TimPierotti.',
-        x=0.50, y=0.06
-    )
+        '40% of first-time buyers used a gift or inheritance.\nHousing is inheritance-sensitive, not just rate-sensitive. h/t @TimPierotti.')
 
     brand_fig(fig,
               title='How First-Time Buyers Are Actually Getting Into Homes',

--- a/Scripts/utilities/lighthouse_chart_style.py
+++ b/Scripts/utilities/lighthouse_chart_style.py
@@ -10,6 +10,41 @@ from matplotlib.patches import FancyBboxPatch
 import matplotlib.dates as mdates
 from matplotlib.ticker import FuncFormatter
 import numpy as np
+import textwrap
+
+
+# =============================================================================
+# ANNOTATION RULE (v4.1, May 2026 — Bob's universal placement)
+# =============================================================================
+
+ANNOTATION_X = 0.5      # axes fraction, horizontal anchor (centered)
+ANNOTATION_Y = 0.98     # axes fraction, vertical anchor (top, va='top')
+ANNOTATION_WRAP_WIDTH = 20  # wrap text when a line exceeds this many chars
+
+
+def wrap_annotation_text(text, width=ANNOTATION_WRAP_WIDTH):
+    """Wrap each line of an annotation at `width` characters.
+
+    Preserves explicit `\\n` in the input. Words are never split mid-token,
+    and hyphens are not used as break points (so figures like "10-year" stay
+    intact).
+
+    This is the canonical wrapping used by `add_callout_box` /
+    `add_annotation_box` across all Lighthouse Macro chart scripts.
+    """
+    if not text:
+        return text
+    out = []
+    for line in text.split('\n'):
+        if line.strip() == '':
+            out.append(line)
+            continue
+        out.append(textwrap.fill(
+            line, width=width,
+            break_long_words=False,
+            break_on_hyphens=False,
+        ))
+    return '\n'.join(out)
 
 # =============================================================================
 # OFFICIAL 8-COLOR PALETTE
@@ -184,27 +219,54 @@ def add_threshold_line(ax, y_value, label, color='red', linestyle='--',
             fontsize=8, color=color, fontweight='bold')
 
 
-def add_callout_box(ax, text, position, boxstyle='round',
-                    facecolor='white', edgecolor=None, fontsize=8):
+def add_callout_box(ax, text, position=None, boxstyle='round',
+                    facecolor='white', edgecolor=None, fontsize=8,
+                    wrap_width=ANNOTATION_WRAP_WIDTH):
     """
-    Add annotation box with key insights
+    Add annotation box with key insights.
 
-    Parameters:
-    -----------
+    UNIVERSAL PLACEMENT RULE (v4.1, May 2026):
+    - Anchor is `(ANNOTATION_X, ANNOTATION_Y)` = `(0.5, 0.98)` in axes
+      coordinates, with `ha='center'`, `va='top'`.
+    - `position` is accepted for backward compatibility but **should not be
+      used to reposition the box per chart**. Pass `position=None` (default)
+      to use the canonical anchor. If a per-chart override is genuinely
+      necessary, do it consciously — the rule is that an annotation that
+      overlaps data should be deleted, not moved.
+    - Text auto-wraps at `wrap_width` characters per line.
+
+    Parameters
+    ----------
     ax : matplotlib axes
-    text : str - Box content
-    position : tuple - (x, y) in axes coordinates
-    boxstyle : str - Box style
+    text : str
+        Box content. Wrapped via `wrap_annotation_text`.
+    position : tuple, optional
+        `(x, y)` in axes coordinates. Defaults to the canonical anchor.
+    boxstyle : str
+        Box style (e.g. `'round'`).
+    facecolor : str
+        Box fill color.
+    edgecolor : str, optional
+        Box border color. Defaults to dusk orange.
+    fontsize : int
+        Text font size.
+    wrap_width : int
+        Wrap text at this many characters per line.
     """
     if edgecolor is None:
         edgecolor = LIGHTHOUSE_COLORS['dusk_orange']
 
+    if position is None:
+        x, y = ANNOTATION_X, ANNOTATION_Y
+    else:
+        x, y = position
+
     props = dict(boxstyle=boxstyle, facecolor=facecolor,
                  edgecolor=edgecolor, alpha=0.95, linewidth=1.5)
 
-    ax.text(position[0], position[1], text,
+    ax.text(x, y, wrap_annotation_text(text, width=wrap_width),
             transform=ax.transAxes, fontsize=fontsize,
-            verticalalignment='top', bbox=props,
+            ha='center', va='top', bbox=props,
             family='monospace')
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bob's rule

> annotation a start at x=0.5, y=0.98. annotations should wrap down to a new line if they're more than 20 x units left to right. avoid annotations when a strong chart and comment will do, use annotations when it's genuinely helpful

Codified as the v4.1 chart-styling rule and applied across every chart_generation script.

## What changed

**Spec** (`Brand/chart-styling.md`, `Brand/chart-styling-for-gemini.md`):

- New "Universal Placement Rule" section under "Annotation Box (Takeaway)".
- Position is fixed at axes `(0.5, 0.98)` with `ha='center'`, `va='top'`.
- Text auto-wraps at 20 characters per line via `textwrap.fill(...)` — words and hyphenated tokens are never split, explicit `\n` is preserved.
- New "When to Annotate vs. Caption" table — use annotations only when the chart can't say it on its own; otherwise write a caption.
- Per-chart `x=/y=` overrides are explicitly disallowed: if the box overlaps data, **delete** the annotation rather than reposition it.

**Canonical helpers**:

- `Scripts/chart_generation/lhm_chart_template.py`: adds `ANNOTATION_X`, `ANNOTATION_Y`, `ANNOTATION_WRAP_WIDTH` constants and `_wrap_annotation_text()`. `add_annotation_box()` now uses the new defaults and wraps text on entry.
- `Scripts/utilities/lighthouse_chart_style.py`: adds `wrap_annotation_text()` plus the same constants. `add_callout_box()` now centers/top-aligns and wraps; the `position` argument is kept for backward compatibility but documented as not-to-be-used per chart.

**Every chart_generation script** with its own `add_annotation_box` definition was updated to use the new signature defaults (`x=ANNOTATION_X, y=ANNOTATION_Y`) and wrap text on entry:

- `business_edu_charts.py`, `btc_etf_charts.py`, `btc_etf_interactive_charts.py`, `consumer_edu_charts.py`, `financial_edu_charts.py`, `government_edu_charts.py`, `growth_edu_charts.py`, `housing_edu_charts.py`, `lhm_chart_template.py`, `plumbing_edu_charts.py`, `positioning_update_2_charts.py`, `prices_edu_charts.py`, `structure_edu_charts.py`, `trade_edu_charts.py`.

**All call sites** had explicit `x=…, y=…` kwargs stripped (so they fall through to the canonical anchor):

- Every `add_annotation_box(…)` call across `Scripts/chart_generation/*.py`, the `financial_edu_charts_interactive.ipynb` cells, `Scripts/build_validation_report.py`, the two `two_economies_*` scripts, and the `fig11_adp_*` / `fig12_adp_*` scripts.

## Verification

- `python3 -m py_compile` passes on all 19 modified `.py` files.
- Manual import of `lhm_chart_template` + wrap helper sanity check:

```
>>> _wrap_annotation_text('High-yield credit spreads are at the 87th percentile. Tight.')
High-yield credit
spreads are at the
87th percentile.
Tight.

>>> inspect.signature(add_annotation_box)
(ax, text, x=0.5, y=0.98, ha='center')
```

## Notes

- The fixed top-center anchor is intentional. Charts where it overlaps data should drop the annotation, not move it — the rule says a strong chart + caption is the preferred alternative.
- A few of the housing/positioning annotations have explicit `\n` inside the source string; those line breaks are preserved by the wrapper, and each segment is wrapped to 20 chars independently. Some now wrap to 4–5 short lines, which is the correct behavior under the new rule.
- The notebook's `ann_x, ann_y = …` setup cells are now dead variables; left in place since they don't affect output and the notebook is a tweak playground.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://lighthousemacro.slack.com/archives/C0ASN649DUN/p1779027280209349?thread_ts=1779027280.209349&cid=C0ASN649DUN)

<div><a href="https://cursor.com/agents/bc-9ddce19a-16ce-5fd7-8c5c-685ddfc2cbf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ddce19a-16ce-5fd7-8c5c-685ddfc2cbf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Standardize chart annotation behavior across the codebase around a universal top-center placement and consistent text wrapping, and update documentation and helper utilities to codify the new rule.

Enhancements:
- Introduce shared annotation constants and wrapping helpers to ensure all annotation boxes anchor at the same axes coordinates and wrap text at 20 characters without splitting words.
- Refine the generic callout/annotation utilities to default to the canonical anchor, center/top alignment, and wrapped text while keeping positional arguments only for backward compatibility.
- Update all chart-generation scripts and interactive notebooks to rely on the new annotation defaults by removing per-chart x/y overrides and letting annotations fall back to the universal placement rule.

Documentation:
- Expand brand chart-styling docs (including Gemini-specific guidance) with a formal universal annotation placement rule, canonical implementation snippet, and guidance on when to use annotations versus captions.