### PR TITLE
Add pytest scaffold and first unit test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: tests
+
+# Runs the unit test suite on every push and pull request. Today nothing
+# prevents a broken transform/index-formula edit from reaching main, where the
+# 15-minute "Daily pipeline sync" auto-commits compound the risk. This is the
+# first gate.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest -ra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+# Project tooling config for the LHM monorepo.
+#
+# This is intentionally minimal: it configures pytest only. The repo is not yet
+# packaged/installable, so the test suite makes the relevant source directories
+# importable via tests/conftest.py rather than an installed distribution.
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = "-ra --strict-markers"
+filterwarnings = [
+    # Surface warnings during tests, but don't let upstream deprecations fail CI.
+    "default",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+# Development & test dependencies for the LHM monorepo.
+# Install with: pip install -r requirements-dev.txt
+#
+# Runtime deps used by the modules under test. Versions are left unpinned to
+# track whatever Bob runs locally; pin here if CI starts drifting.
+pandas
+numpy
+pytest

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,30 @@
+# LHM Test Suite
+
+First automated tests for the monorepo. This is an initial, high-ROI slice
+covering the **pure numeric logic** that the whole pipeline depends on.
+
+## Running
+
+```bash
+pip install -r requirements-dev.txt   # pandas, numpy, pytest
+pytest                                # from the repo root
+```
+
+`tests/conftest.py` puts the repo root and `Scripts/data_pipeline/` on
+`sys.path`, so no install/packaging step is required.
+
+## What's covered
+
+| File | Module under test | Focus |
+|------|-------------------|-------|
+| `test_transforms.py` | `lighthouse/transforms.py` | YoY/MoM/annualized transforms, rolling z-score, series-type & frequency inference, `apply_transforms` composition |
+| `test_quality.py` | `lighthouse/quality.py` | Missing-value / variance / outlier / staleness / duplicate gates and `validate_series` composition |
+| `test_index_status.py` | `compute_indices.py` | `get_status` threshold bands (MRI/LFI + monotonicity invariant) and the strict NaN-propagating composite math (`weighted_sum_strict`, `all_present_mean`, `compute_zscore`) |
+
+## Not yet covered (suggested next slices)
+
+- `lighthouse_quant/config.py` invariants (publication lags, NBER recession
+  ordering, indicator relationships)
+- Fetcher response parsing (FRED/BLS/BEA/OFR) via saved JSON/CSV fixtures
+- Pipeline DB writes / `query.py` reads against in-memory SQLite
+- `lighthouse_quant/models/` (recession probability, warning-system override rules)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Shared pytest fixtures and import-path setup for the LHM test suite.
+
+The repo is not an installable package, and several modules live as loose
+scripts under ``Scripts/data_pipeline``. To import them in tests we put both
+the repo root and ``Scripts/data_pipeline`` on ``sys.path`` here, once, before
+any test module imports the code under test.
+
+Path layout this enables:
+    import lighthouse.transforms          # Scripts/data_pipeline/lighthouse/
+    import compute_indices                # Scripts/data_pipeline/
+    import lighthouse_quant.config        # repo root
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PIPELINE_DIR = REPO_ROOT / "Scripts" / "data_pipeline"
+
+for p in (REPO_ROOT, PIPELINE_DIR):
+    sp = str(p)
+    if sp not in sys.path:
+        sys.path.insert(0, sp)
+
+
+@pytest.fixture
+def monthly_index():
+    """A clean 36-month month-start DatetimeIndex ending recently."""
+    end = pd.Timestamp.today().normalize().replace(day=1)
+    return pd.date_range(end=end, periods=36, freq="MS")
+
+
+@pytest.fixture
+def rising_series(monthly_index):
+    """A strictly increasing monthly series (100, 101, ... )."""
+    return pd.Series(
+        np.arange(100.0, 100.0 + len(monthly_index)),
+        index=monthly_index,
+        name="value",
+    )
+
+
+@pytest.fixture
+def clean_value_df(rising_series):
+    """A DataFrame with a 'value' column on a recent monthly DatetimeIndex.
+
+    Passes every quality check: enough obs, no missing, non-zero variance,
+    no extreme outliers, no duplicate dates, and a fresh last observation.
+    """
+    return rising_series.to_frame(name="value")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ Path layout this enables:
 """
 
 import sys
+import types
 from pathlib import Path
 
 import numpy as np
@@ -25,6 +26,27 @@ for p in (REPO_ROOT, PIPELINE_DIR):
     sp = str(p)
     if sp not in sys.path:
         sys.path.insert(0, sp)
+
+# Register a lightweight stub for the ``lighthouse`` package *before* anything
+# imports its submodules.
+#
+# The real ``Scripts/data_pipeline/lighthouse/__init__.py`` eagerly imports the
+# pipeline -> fetchers chain, which pulls in heavy runtime-only deps (e.g.
+# ``requests``). The modules under test (transforms, quality, config) and the
+# compute_indices import chain don't need any of that. We give the package a
+# ``__path__`` pointing at the real directory but an empty ``__init__`` body, so
+# ``import lighthouse.transforms`` / ``from lighthouse.config import ...`` (and
+# quality's relative ``from .config import ...``) resolve the individual source
+# files directly without executing the eager package init.
+#
+# If the suite grows to cover the fetcher/pipeline stack itself, add the runtime
+# deps to requirements-dev.txt and import those modules explicitly instead.
+_LIGHTHOUSE_DIR = PIPELINE_DIR / "lighthouse"
+if "lighthouse" not in sys.modules and _LIGHTHOUSE_DIR.is_dir():
+    _pkg = types.ModuleType("lighthouse")
+    _pkg.__path__ = [str(_LIGHTHOUSE_DIR)]
+    _pkg.__package__ = "lighthouse"
+    sys.modules["lighthouse"] = _pkg
 
 
 @pytest.fixture

--- a/tests/test_index_status.py
+++ b/tests/test_index_status.py
@@ -1,0 +1,137 @@
+"""Unit tests for the pure index logic in Scripts/data_pipeline/compute_indices.py.
+
+This is the firm's IP: the status-label thresholds that drive client-facing
+regime classifications (RECESSION / LATE CYCLE / CRITICAL ...), and the
+canonical composite math (strict NaN-propagating weighted sums + z-scores).
+Boundary tests here protect the published formulas from accidental edits.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import compute_indices as CI
+
+
+# --------------------------------------------------------------------------
+# get_status — threshold classification
+# --------------------------------------------------------------------------
+
+def test_get_status_nan_is_no_data():
+    assert CI.get_status("MRI", np.nan) == "NO DATA"
+
+
+def test_get_status_unknown_index_returns_unknown():
+    assert CI.get_status("NOT_AN_INDEX", 0.5) == "UNKNOWN"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0.60, "RECESSION"),
+        (0.50, "RECESSION"),      # boundary is inclusive (>=)
+        (0.30, "PRE-RECESSION"),
+        (0.15, "LATE CYCLE"),
+        (0.00, "MID-CYCLE"),
+        (-0.50, "EARLY EXPANSION"),
+    ],
+)
+def test_get_status_mri_bands(value, expected):
+    assert CI.get_status("MRI", value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (1.6, "CRITICAL"),
+        (1.5, "CRITICAL"),        # boundary inclusive
+        (1.0, "HIGH"),
+        (0.5, "ELEVATED"),
+        (0.0, "NEUTRAL"),
+        (-2.0, "HEALTHY"),
+    ],
+)
+def test_get_status_lfi_bands(value, expected):
+    assert CI.get_status("LFI", value) == expected
+
+
+def test_status_thresholds_are_monotonic_with_catchall():
+    """Every threshold table must be sorted descending and end in a -999 catch-all.
+
+    This invariant is what makes get_status's first-match-wins loop correct;
+    if an edit breaks ordering, some bands become unreachable.
+    """
+    for index_name, bands in CI.STATUS_THRESHOLDS.items():
+        cutoffs = [c for c, _ in bands]
+        assert cutoffs == sorted(cutoffs, reverse=True), (
+            f"{index_name} thresholds not descending: {cutoffs}"
+        )
+        assert cutoffs[-1] == -999, f"{index_name} missing -999 catch-all"
+
+
+# --------------------------------------------------------------------------
+# weighted_sum_strict — canonical composite formula
+# --------------------------------------------------------------------------
+
+def test_weighted_sum_strict_basic():
+    idx = pd.date_range("2020-01-01", periods=3, freq="MS")
+    a = pd.Series([1.0, 2.0, 3.0], index=idx)
+    b = pd.Series([10.0, 20.0, 30.0], index=idx)
+    out = CI.weighted_sum_strict([(a, 0.5), (b, 0.5)])
+    expected = 0.5 * a + 0.5 * b
+    pd.testing.assert_series_equal(out, expected, check_names=False)
+
+
+def test_weighted_sum_strict_nan_propagates():
+    idx = pd.date_range("2020-01-01", periods=3, freq="MS")
+    a = pd.Series([1.0, np.nan, 3.0], index=idx)
+    b = pd.Series([10.0, 20.0, 30.0], index=idx)
+    out = CI.weighted_sum_strict([(a, 0.5), (b, 0.5)])
+    # Missing input at position 1 nulls the composite there — no silent reweight.
+    assert np.isnan(out.iloc[1])
+    assert out.iloc[0] == pytest.approx(5.5)
+    assert out.iloc[2] == pytest.approx(16.5)
+
+
+def test_weighted_sum_strict_empty_is_empty_series():
+    out = CI.weighted_sum_strict([])
+    assert isinstance(out, pd.Series) and out.empty
+
+
+# --------------------------------------------------------------------------
+# all_present_mean — equal-weight composite
+# --------------------------------------------------------------------------
+
+def test_all_present_mean_basic_and_nan_propagation():
+    idx = pd.date_range("2020-01-01", periods=3, freq="MS")
+    a = pd.Series([1.0, 2.0, np.nan], index=idx)
+    b = pd.Series([3.0, 4.0, 5.0], index=idx)
+    out = CI.all_present_mean(a, b)
+    assert out.iloc[0] == pytest.approx(2.0)
+    assert out.iloc[1] == pytest.approx(3.0)
+    assert np.isnan(out.iloc[2])  # strict: any NaN -> NaN
+
+
+def test_all_present_mean_empty_is_empty_series():
+    out = CI.all_present_mean()
+    assert isinstance(out, pd.Series) and out.empty
+
+
+# --------------------------------------------------------------------------
+# compute_zscore — division-by-zero protection
+# --------------------------------------------------------------------------
+
+def test_compute_zscore_constant_window_is_nan_not_inf():
+    s = pd.Series([3.0] * 30)
+    out = CI.compute_zscore(s, window=24)
+    # std is 0 across the window -> replaced with NaN -> no inf leaks through.
+    assert not np.isinf(out.to_numpy()).any()
+    assert out.dropna().empty
+
+
+def test_compute_zscore_known_value():
+    s = pd.Series([0.0, 0.0, 0.0, 0.0, 4.0])
+    out = CI.compute_zscore(s, window=5, min_periods=5)
+    win = s.to_numpy()
+    expected = (4.0 - win.mean()) / win.std(ddof=1)
+    assert out.iloc[4] == pytest.approx(expected)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,160 @@
+"""Unit tests for Scripts/data_pipeline/lighthouse/quality.py.
+
+These are the guardrails that are supposed to stop bad/stale data reaching
+clients. A regression that silently turns a check into a no-op is exactly the
+failure mode worth pinning down. All check functions are pure: they take a
+DataFrame/args and return an issue string or None.
+"""
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lighthouse import quality as Q
+from lighthouse.config import QUALITY_CONFIG
+
+
+# --------------------------------------------------------------------------
+# check_missing_values
+# --------------------------------------------------------------------------
+
+def test_missing_values_empty_dataframe():
+    msg = Q.check_missing_values(pd.DataFrame({"value": []}), "SID")
+    assert msg is not None and "Empty" in msg
+
+
+def test_missing_values_above_threshold_flags():
+    # 3 of 4 missing = 75% > default 50% threshold.
+    df = pd.DataFrame({"value": [1.0, np.nan, np.nan, np.nan]})
+    msg = Q.check_missing_values(df, "SID")
+    assert msg is not None and "missing" in msg
+
+
+def test_missing_values_below_threshold_passes():
+    df = pd.DataFrame({"value": [1.0, 2.0, 3.0, np.nan]})  # 25% missing
+    assert Q.check_missing_values(df, "SID") is None
+
+
+# --------------------------------------------------------------------------
+# check_zero_variance
+# --------------------------------------------------------------------------
+
+def test_zero_variance_constant_series_flags():
+    df = pd.DataFrame({"value": [7.0, 7.0, 7.0]})
+    assert Q.check_zero_variance(df, "SID") is not None
+
+
+def test_zero_variance_varying_series_passes():
+    df = pd.DataFrame({"value": [1.0, 2.0, 3.0]})
+    assert Q.check_zero_variance(df, "SID") is None
+
+
+# --------------------------------------------------------------------------
+# check_outliers
+# --------------------------------------------------------------------------
+
+def test_outliers_too_few_points_returns_none():
+    df = pd.DataFrame({"value": [1.0, 100.0]})
+    assert Q.check_outliers(df, "SID", z_threshold=2) is None
+
+
+def test_outliers_flagged_when_above_explicit_threshold():
+    df = pd.DataFrame({"value": [1.0, 1.0, 1.0, 1.0, 50.0]})
+    msg = Q.check_outliers(df, "SID", z_threshold=1.5)
+    assert msg is not None and "outlier" in msg.lower()
+
+
+def test_outliers_constant_series_returns_none():
+    # Zero std must not raise / must not flag.
+    df = pd.DataFrame({"value": [5.0, 5.0, 5.0, 5.0]})
+    assert Q.check_outliers(df, "SID", z_threshold=2) is None
+
+
+def test_outliers_default_threshold_is_lenient():
+    # Default threshold (10) should not flag a mild 3-sigma spike.
+    base = [1.0, 2.0, 3.0, 2.0, 1.0, 2.0, 3.0, 2.0]
+    df = pd.DataFrame({"value": base + [6.0]})
+    assert Q.check_outliers(df, "SID") is None
+
+
+# --------------------------------------------------------------------------
+# check_staleness
+# --------------------------------------------------------------------------
+
+def test_staleness_no_date():
+    assert "No data" in Q.check_staleness("", "M", "SID")
+
+
+def test_staleness_invalid_date():
+    assert "Invalid date" in Q.check_staleness("not-a-date", "M", "SID")
+
+
+def test_staleness_fresh_monthly_passes():
+    recent = (datetime.now() - timedelta(days=10)).strftime("%Y-%m-%d")
+    assert Q.check_staleness(recent, "M", "SID") is None
+
+
+def test_staleness_old_monthly_flags():
+    old = (datetime.now() - timedelta(days=200)).strftime("%Y-%m-%d")
+    msg = Q.check_staleness(old, "M", "SID")
+    assert msg is not None and "Stale" in msg
+
+
+def test_staleness_thresholds_differ_by_frequency():
+    # 30 days old: stale for daily (7d) but fresh for monthly (75d).
+    d = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
+    assert Q.check_staleness(d, "D", "SID") is not None
+    assert Q.check_staleness(d, "M", "SID") is None
+
+
+# --------------------------------------------------------------------------
+# check_negative_values / check_duplicates
+# --------------------------------------------------------------------------
+
+def test_negative_values_allowed_by_default():
+    df = pd.DataFrame({"value": [-1.0, 2.0]})
+    assert Q.check_negative_values(df, "SID") is None
+
+
+def test_negative_values_flagged_when_disallowed():
+    df = pd.DataFrame({"value": [-1.0, 2.0, -3.0]})
+    msg = Q.check_negative_values(df, "SID", allow_negative=False)
+    assert msg is not None and "negative" in msg
+
+
+def test_duplicates_on_date_column():
+    df = pd.DataFrame({"date": ["2020-01-01", "2020-01-01", "2020-02-01"],
+                       "value": [1.0, 2.0, 3.0]})
+    msg = Q.check_duplicates(df, "SID")
+    assert msg is not None and "duplicate" in msg
+
+
+def test_duplicates_none_when_unique():
+    df = pd.DataFrame({"date": ["2020-01-01", "2020-02-01"], "value": [1.0, 2.0]})
+    assert Q.check_duplicates(df, "SID") is None
+
+
+# --------------------------------------------------------------------------
+# validate_series (composition)
+# --------------------------------------------------------------------------
+
+def test_validate_series_insufficient_data_short_circuits():
+    df = pd.DataFrame({"value": [1.0, 2.0]})  # below min_observations
+    issues = Q.validate_series(df, "SID", frequency="M")
+    assert len(issues) == 1 and "Insufficient" in issues[0]
+
+
+def test_validate_series_clean_series_has_no_issues(clean_value_df):
+    issues = Q.validate_series(clean_value_df, "SID", frequency="M")
+    assert issues == []
+
+
+def test_validate_series_collects_multiple_issues():
+    # Constant series: triggers zero-variance; long enough to pass min obs.
+    n = QUALITY_CONFIG["min_observations"] + 5
+    idx = pd.date_range(end=pd.Timestamp.today(), periods=n, freq="MS")
+    df = pd.DataFrame({"value": [5.0] * n}, index=idx)
+    issues = Q.validate_series(df, "SID", frequency="M")
+    assert any("Zero variance" in i for i in issues)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,193 @@
+"""Unit tests for Scripts/data_pipeline/lighthouse/transforms.py.
+
+These transforms are the single source of truth that feeds every downstream
+index, so a silent off-by-one in period mapping or a sign error here corrupts
+the whole pipeline. They are pure functions over pandas Series — cheap to pin
+down exactly.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lighthouse import transforms as T
+
+
+# --------------------------------------------------------------------------
+# Core arithmetic transforms
+# --------------------------------------------------------------------------
+
+def test_yoy_pct_basic():
+    s = pd.Series([100.0, 110.0, 121.0])
+    out = T.yoy_pct(s, periods=1)
+    assert np.isnan(out.iloc[0])
+    assert out.iloc[1] == pytest.approx(10.0)
+    assert out.iloc[2] == pytest.approx(10.0)
+
+
+def test_yoy_pct_default_period_is_12():
+    s = pd.Series(range(1, 25), dtype=float)  # 24 obs
+    out = T.yoy_pct(s)  # default periods=12
+    # First 12 are NaN (no value 12 periods back)
+    assert out.iloc[:12].isna().all()
+    # value[12]=13 vs value[0]=1 -> 1200% change
+    assert out.iloc[12] == pytest.approx(1200.0)
+
+
+def test_yoy_diff_is_simple_difference():
+    s = pd.Series([1.0, 2.0, 5.0])
+    out = T.yoy_diff(s, periods=1)
+    assert np.isnan(out.iloc[0])
+    assert out.iloc[1] == pytest.approx(1.0)
+    assert out.iloc[2] == pytest.approx(3.0)
+
+
+def test_mom_pct_and_mom_diff():
+    s = pd.Series([200.0, 220.0])
+    assert T.mom_pct(s).iloc[1] == pytest.approx(10.0)
+    assert T.mom_diff(s).iloc[1] == pytest.approx(20.0)
+
+
+def test_ann_3m_annualizes_to_the_fourth_power():
+    # A constant 1% step compounded over 3 months, annualized (^4).
+    s = pd.Series([100.0, 100.0, 100.0, 101.0])
+    out = T.ann_3m(s)
+    expected = (((101.0 / 100.0) ** 4) - 1) * 100
+    assert out.iloc[3] == pytest.approx(expected)
+
+
+def test_ann_6m_annualizes_to_the_second_power():
+    s = pd.Series([100.0] * 6 + [102.0])
+    out = T.ann_6m(s)
+    expected = (((102.0 / 100.0) ** 2) - 1) * 100
+    assert out.iloc[6] == pytest.approx(expected)
+
+
+# --------------------------------------------------------------------------
+# Rolling z-score
+# --------------------------------------------------------------------------
+
+def test_z_score_min_periods_half_window():
+    # window=4 -> min_periods=2, so index 0 is NaN, index 1 onward defined.
+    s = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+    out = T.z_score(s, window=4)
+    assert np.isnan(out.iloc[0])
+    assert not np.isnan(out.iloc[1])
+
+
+def test_z_score_constant_series_is_nan_or_inf_free_div():
+    # Constant series -> std 0 -> division by zero -> NaN/inf, never a finite z.
+    s = pd.Series([5.0] * 10)
+    out = T.z_score(s, window=4)
+    assert not np.isfinite(out.dropna()).any()
+
+
+def test_z_score_known_value():
+    # On a window where mean and std are analytically known.
+    s = pd.Series([0.0, 0.0, 0.0, 0.0, 4.0])
+    out = T.z_score(s, window=5)
+    # window of all 5: mean=0.8, sample std = sqrt(variance).
+    win = s.values
+    expected = (4.0 - win.mean()) / win.std(ddof=1)
+    assert out.iloc[4] == pytest.approx(expected)
+
+
+# --------------------------------------------------------------------------
+# Series-type inference (keyword precedence matters)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "series_id, title, expected",
+    [
+        ("DGS10", "10-Year Treasury Constant Maturity Rate", "rate"),
+        ("BAMLH0A0HYM2", "ICE BofA US High Yield OAS", "rate"),
+        ("VIXCLS", "CBOE Volatility Index", "index"),
+        ("NFCI", "Chicago Fed National Financial Conditions Index", "index"),
+        ("TCU", "Capacity Utilization", "ratio"),
+        ("PCEPI", "Personal Consumption Expenditures Price Deflator", "price"),
+        ("PAYEMS", "All Employees Total Nonfarm", "level"),
+    ],
+)
+def test_infer_series_type(series_id, title, expected):
+    assert T.infer_series_type(series_id, title) == expected
+
+
+def test_infer_series_type_rate_keyword_wins_over_ratio():
+    # "Unemployment Rate" contains both 'unemployment' (ratio) and 'rate'.
+    # 'rate' is checked first, so the documented behavior is 'rate'.
+    assert T.infer_series_type("UNRATE", "Unemployment Rate") == "rate"
+
+
+def test_infer_series_type_handles_none_title():
+    assert T.infer_series_type("SOMEID", None) == "level"
+
+
+# --------------------------------------------------------------------------
+# Frequency inference & period mapping
+# --------------------------------------------------------------------------
+
+def test_infer_frequency_monthly():
+    df = pd.DataFrame({"value": range(12)},
+                      index=pd.date_range("2020-01-01", periods=12, freq="MS"))
+    assert T.infer_frequency(df) == "M"
+
+
+def test_infer_frequency_daily_and_unknown():
+    daily = pd.DataFrame({"value": range(10)},
+                         index=pd.date_range("2020-01-01", periods=10, freq="D"))
+    assert T.infer_frequency(daily) == "D"
+    # Fewer than 3 rows -> Unknown.
+    tiny = pd.DataFrame({"value": [1, 2]},
+                        index=pd.date_range("2020-01-01", periods=2, freq="D"))
+    assert T.infer_frequency(tiny) == "U"
+
+
+def test_get_periods_for_freq_known_and_default():
+    assert T.get_periods_for_freq("M") == {"yoy": 12, "mom": 1, "z_window": 24}
+    assert T.get_periods_for_freq("Q") == {"yoy": 4, "mom": 1, "z_window": 8}
+    # Unknown frequency falls back to monthly mapping.
+    assert T.get_periods_for_freq("ZZZ") == T.get_periods_for_freq("M")
+
+
+# --------------------------------------------------------------------------
+# Default-transform selection
+# --------------------------------------------------------------------------
+
+def test_get_default_transforms_by_type():
+    assert T.get_default_transforms("rate", "M") == ["diff", "yoy_diff", "z"]
+    assert T.get_default_transforms("price", "M") == [
+        "yoy_pct", "mom_pct", "3m_ann", "6m_ann",
+    ]
+
+
+def test_get_default_transforms_level_is_frequency_aware():
+    assert T.get_default_transforms("level", "M") == ["yoy_pct", "mom_pct", "z"]
+    assert T.get_default_transforms("level", "Q") == ["yoy_pct", "qoq_pct", "z"]
+    assert T.get_default_transforms("level", "D") == ["yoy_pct", "wow_pct", "z"]
+
+
+# --------------------------------------------------------------------------
+# apply_transforms composition
+# --------------------------------------------------------------------------
+
+def test_apply_transforms_uses_frequency_aware_periods():
+    s = pd.Series(range(1, 25), dtype=float,
+                  index=pd.date_range("2020-01-01", periods=24, freq="MS"))
+    out = T.apply_transforms(s, ["yoy_pct", "z"], freq="M")
+    assert list(out.columns) == ["raw", "yoy_pct", "z"]
+    # yoy_pct uses the 12-period mapping for monthly data.
+    assert out["yoy_pct"].iloc[:12].isna().all()
+    assert out["yoy_pct"].iloc[12] == pytest.approx(1200.0)
+
+
+def test_apply_transforms_swallows_unknown_transform():
+    s = pd.Series([1.0, 2.0, 3.0])
+    out = T.apply_transforms(s, ["not_a_real_transform"], freq="M")
+    # Unknown transforms are skipped silently; only 'raw' survives.
+    assert list(out.columns) == ["raw"]
+
+
+def test_apply_transforms_df_requires_value_column():
+    df = pd.DataFrame({"not_value": [1, 2, 3]})
+    with pytest.raises(ValueError):
+        T.apply_transforms_df(df, ["yoy_pct"], freq="M")


### PR DESCRIPTION
## Why

A test-coverage analysis found the monorepo has **271 active Python files and zero real unit tests** — the only `*test*.py` files are backtest CLI tools and archived scripts. There's no test framework, no `requirements.txt`, and no CI gate, so a silent off-by-one in a transform or an accidental edit to an index threshold can reach `main` (where the 15-minute "Daily pipeline sync" auto-commits compound the risk) with nothing to catch it.

This PR lands the **highest-ROI, lowest-risk slice first**: the pure numeric logic the whole pipeline depends on.

## What's in here

**Scaffolding**
- `pyproject.toml` — pytest config (no packaging required)
- `requirements-dev.txt` — pandas, numpy, pytest
- `tests/conftest.py` — wires `sys.path` (repo root + `Scripts/data_pipeline/`) and shared fixtures
- `.github/workflows/tests.yml` — runs `pytest` on every push/PR (Python 3.10 + 3.11)

**Tests (69, all passing)**
| File | Module under test | Focus |
|------|-------------------|-------|
| `test_transforms.py` | `lighthouse/transforms.py` | YoY/MoM/annualized transforms, rolling z-score, series-type & frequency inference, `apply_transforms` composition |
| `test_quality.py` | `lighthouse/quality.py` | missing / variance / outlier / staleness / duplicate gates + `validate_series` |
| `test_index_status.py` | `compute_indices.py` | `get_status` threshold bands (MRI/LFI + a monotonicity invariant across **all** status tables) and the strict NaN-propagating composite math (`weighted_sum_strict`, `all_present_mean`, `compute_zscore`) |

The index tests pin the published thresholds and the "any missing input → NaN" composite contract, so future edits to the firm's IP fail loudly.

## Suggested next slices (not in this PR)
- `lighthouse_quant/config.py` invariants (publication lags, NBER recession ordering, indicator relationships)
- Fetcher response parsing (FRED/BLS/BEA/OFR) via saved JSON/CSV fixtures
- Pipeline DB writes / `query.py` reads against in-memory SQLite
- `lighthouse_quant/models/` — recession probability + warning-system override rules
- Address the ~320 hardcoded `/Users/bob/...` paths that block tests/CI on non-Mac environments

## Test plan
```bash
pip install -r requirements-dev.txt
pytest            # 69 passed
```

https://claude.ai/code/session_01Q5V6cFecFCkvTDYnFBZrr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5V6cFecFCkvTDYnFBZrr9)_

## Summary by Sourcery

Introduce an initial pytest-based test suite and CI gate for the core numeric pipeline logic.

New Features:
- Add unit tests for lighthouse transforms, quality checks, and index status/composite calculations.
- Add a tests README describing coverage and how to run the suite.

Enhancements:
- Configure pytest via pyproject.toml for consistent local and CI test execution.

Build:
- Add a requirements-dev.txt with numpy, pandas, and pytest for local and CI test dependencies.

CI:
- Add a GitHub Actions workflow to run pytest on pushes and pull requests across Python 3.10 and 3.11.

Tests:
- Add comprehensive unit tests for time-series transforms including YoY/MoM/annualized calculations, rolling z-scores, and transform application pipelines.
- Add unit tests for data quality checks covering missing data, variance, outliers, staleness, negatives, duplicates, and validate_series composition.
- Add unit tests for index status thresholds and composite math, including NaN-propagating weighted sums and z-score computation.
- Add shared pytest fixtures and path wiring in tests/conftest.py to support testing non-packaged pipeline modules.